### PR TITLE
Security: Sanitize terminal title to prevent escape sequence injection

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -142,8 +142,20 @@ func ShowCursor() {
 }
 
 // SetTerminalTitle sets the terminal tab/window title
+// The title is sanitized to prevent terminal escape sequence injection
 func SetTerminalTitle(title string) {
-	fmt.Printf("\033]0;%s\007", title)
+	fmt.Printf("\033]0;%s\007", sanitizeForTerminal(title))
+}
+
+// sanitizeForTerminal removes control characters that could be used
+// for terminal escape sequence injection attacks
+func sanitizeForTerminal(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 32 || r == 127 {
+			return -1 // Remove control characters
+		}
+		return r
+	}, s)
 }
 
 // ResetTerminalTitle resets the terminal title to default


### PR DESCRIPTION
## Summary
- Add `sanitizeForTerminal()` function that removes control characters from strings before using them in terminal escape sequences
- Apply sanitization in `SetTerminalTitle()` to prevent potential injection attacks

## Details
Control characters (ASCII < 32 and DEL/127) are stripped from the title string before it's passed to the terminal escape sequence. This prevents malicious escape sequences from being injected through user-controlled data.

## Test plan
- [x] Code compiles successfully (`go build ./...`)
- [x] Manual testing: verify terminal title displays correctly

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)