### PR TITLE
Remove Idle and Inactive from live view status bar

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -93,9 +93,7 @@ func RenderLive(sessions []session.Session) {
 	counts := countByStatus(active)
 	fmt.Printf("%s%s Working: %d%s  ", Green, SymbolWorking, counts[session.StatusWorking], Reset)
 	fmt.Printf("%s%s Needs Input: %d%s  ", Yellow, SymbolNeedsInput, counts[session.StatusNeedsInput], Reset)
-	fmt.Printf("%s%s Waiting: %d%s  ", Blue, SymbolWaiting, counts[session.StatusWaiting], Reset)
-	fmt.Printf("%s%s Idle: %d%s  ", Gray, SymbolIdle, counts[session.StatusIdle], Reset)
-	fmt.Printf("%s%s Inactive: %d%s", Dim, SymbolInactive, len(inactive), Reset)
+	fmt.Printf("%s%s Waiting: %d%s", Blue, SymbolWaiting, counts[session.StatusWaiting], Reset)
 	fmt.Print("\r\n\r\n")
 
 	if len(active) == 0 {
@@ -167,12 +165,12 @@ func ResetTerminalTitle() {
 func buildTerminalTitle(sessions []session.Session) string {
 	counts := make(map[session.Status]int)
 	for _, s := range sessions {
-		if s.Status != session.StatusInactive {
+		if s.Status != session.StatusInactive && !s.IsGhost {
 			counts[s.Status]++
 		}
 	}
 
-	// Priority: Needs Input > Working > Waiting > Idle
+	// Priority: Needs Input > Working > Waiting
 	var parts []string
 
 	if n := counts[session.StatusNeedsInput]; n > 0 {
@@ -183,9 +181,6 @@ func buildTerminalTitle(sessions []session.Session) string {
 	}
 	if n := counts[session.StatusWaiting]; n > 0 {
 		parts = append(parts, fmt.Sprintf("%d waiting", n))
-	}
-	if n := counts[session.StatusIdle]; n > 0 {
-		parts = append(parts, fmt.Sprintf("%d idle", n))
 	}
 
 	if len(parts) == 0 {


### PR DESCRIPTION
## Summary

- Remove "Idle" and "Inactive" counts from the top status bar in live view
- Idle status was never actually assigned (dead code always showing 0)
- Inactive sessions already have a dedicated history view accessible via `h` key
- Live view now focuses on active session states: Working, Needs Input, Waiting

## Test plan

- [x] Run `csm` with active sessions - verify only Working/Needs Input/Waiting shown in status bar
- [x] Run `csm` with no active sessions - verify terminal title shows "no active sessions"
- [x] Check terminal tab title updates correctly with session counts

🤖 Generated with [Claude Code](https://claude.ai/code)