### PR TITLE
Fix path encoding to handle dots in directory names

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -133,7 +133,10 @@ func getRunningClaudeDirs() map[string]int {
 // encodeProjectPath converts a filesystem path to the encoded directory name format
 func encodeProjectPath(path string) string {
 	// /Users/username/Projects/org/project -> -Users-username-Projects-org-project
-	return strings.ReplaceAll(path, "/", "-")
+	// Also replace dots with dashes (Claude's encoding scheme)
+	encoded := strings.ReplaceAll(path, "/", "-")
+	encoded = strings.ReplaceAll(encoded, ".", "-")
+	return encoded
 }
 
 // isDesktopSession checks if the project path appears to be from the desktop app


### PR DESCRIPTION
## Summary
- Fix session detection for projects with dots in their directory names (e.g., `deltag.aarhus.dk`)
- Claude encodes paths by replacing both `/` and `.` with `-`, but csm only replaced `/`
- This caused running sessions to appear as Inactive instead of Working/Waiting

## Test plan
- [x] Verified fix detects sessions in `deltag.aarhus.dk` directory correctly
- [x] Run `csm -l` with projects containing dots in their names

🤖 Generated with [Claude Code](https://claude.com/claude-code)