### PR TITLE
feat: responsive table layout for different terminal widths

### DIFF
--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -1,0 +1,146 @@
+package ui
+
+// Column width constraints for session table
+const (
+	fixedStatusWidth   = 14 // "● Needs Input" = 13 chars + 1 padding
+	fixedContextWidth  = 16 // progress bar (10) + " 100%" (5) + 1 padding
+	fixedActivityWidth = 15 // "LAST ACTIVITY" header + padding
+	minProjectWidth    = 15
+	prefProjectWidth   = 35
+	minMessageWidth    = 10
+	prefMessageWidth   = 40
+)
+
+// sessionLayout holds the computed column widths for the session table.
+type sessionLayout struct {
+	status      int
+	project     int
+	context     int
+	activity    int
+	message     int
+	showMessage bool
+	totalWidth  int
+}
+
+// calcSessionLayout computes column widths for the given terminal width.
+// Fixed columns (status, context, activity) keep their size.
+// Flexible columns (project, message) share remaining space.
+// If the terminal is too narrow, LAST MESSAGE is hidden.
+func calcSessionLayout(width int) sessionLayout {
+	l := sessionLayout{
+		status:   fixedStatusWidth,
+		context:  fixedContextWidth,
+		activity: fixedActivityWidth,
+	}
+
+	fixed := l.status + l.context + l.activity
+	remaining := width - fixed
+
+	// Try to fit both project and message columns
+	minBoth := minProjectWidth + minMessageWidth
+	if remaining >= minBoth {
+		l.showMessage = true
+
+		// Distribute remaining space between project and message
+		// Give project up to its preferred width first, rest to message
+		l.project = prefProjectWidth
+		if l.project > remaining-minMessageWidth {
+			l.project = remaining - minMessageWidth
+		}
+		if l.project < minProjectWidth {
+			l.project = minProjectWidth
+		}
+		l.message = remaining - l.project
+
+		// Cap message at preferred width, give overflow back to project
+		if l.message > prefMessageWidth {
+			extra := l.message - prefMessageWidth
+			l.message = prefMessageWidth
+			l.project += extra
+		}
+	} else {
+		// Not enough room for message column - give all to project
+		l.showMessage = false
+		l.message = 0
+		l.project = remaining
+		if l.project < 1 {
+			l.project = 1
+		}
+	}
+
+	l.totalWidth = l.status + l.project + l.context + l.activity
+	if l.showMessage {
+		l.totalWidth += l.message
+	}
+
+	return l
+}
+
+// Column width constraints for history table
+const (
+	minHistProjectWidth  = 15
+	prefHistProjectWidth = 27
+	fixedBranchWidth     = 12
+	fixedDurationWidth   = 10
+	fixedMsgsWidth       = 6
+	minHistContextWidth  = 15
+	prefHistContextWidth = 35
+)
+
+// historyLayout holds the computed column widths for the history table.
+type historyLayout struct {
+	project     int
+	branch      int
+	duration    int
+	msgs        int
+	context     int
+	showContext bool
+	totalWidth  int
+}
+
+// calcHistoryLayout computes column widths for the history table.
+func calcHistoryLayout(width int) historyLayout {
+	l := historyLayout{
+		branch:   fixedBranchWidth,
+		duration: fixedDurationWidth,
+		msgs:     fixedMsgsWidth,
+	}
+
+	fixed := l.branch + l.duration + l.msgs
+	remaining := width - fixed
+
+	// Try to fit both project and context columns
+	minBoth := minHistProjectWidth + minHistContextWidth
+	if remaining >= minBoth {
+		l.showContext = true
+
+		l.project = prefHistProjectWidth
+		if l.project > remaining-minHistContextWidth {
+			l.project = remaining - minHistContextWidth
+		}
+		if l.project < minHistProjectWidth {
+			l.project = minHistProjectWidth
+		}
+		l.context = remaining - l.project
+
+		if l.context > prefHistContextWidth {
+			extra := l.context - prefHistContextWidth
+			l.context = prefHistContextWidth
+			l.project += extra
+		}
+	} else {
+		l.showContext = false
+		l.context = 0
+		l.project = remaining
+		if l.project < 1 {
+			l.project = 1
+		}
+	}
+
+	l.totalWidth = l.project + l.branch + l.duration + l.msgs
+	if l.showContext {
+		l.totalWidth += l.context
+	}
+
+	return l
+}

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -1,0 +1,108 @@
+package ui
+
+import "testing"
+
+func TestCalcSessionLayout_WideTerminal(t *testing.T) {
+	l := calcSessionLayout(140)
+
+	if !l.showMessage {
+		t.Error("expected LAST MESSAGE column visible at 140 cols")
+	}
+	if l.status != 14 {
+		t.Errorf("expected status=14, got %d", l.status)
+	}
+	if l.context != 16 {
+		t.Errorf("expected context=16, got %d", l.context)
+	}
+	if l.activity != 15 {
+		t.Errorf("expected activity=15, got %d", l.activity)
+	}
+	// project + message should use the remaining space
+	total := l.status + l.project + l.context + l.activity + l.message
+	if total != 140 {
+		t.Errorf("expected columns to sum to 140, got %d", total)
+	}
+}
+
+func TestCalcSessionLayout_NarrowTerminal(t *testing.T) {
+	l := calcSessionLayout(80)
+
+	// At 80 cols the LAST MESSAGE column should still be visible but narrow
+	if l.status != 14 {
+		t.Errorf("expected status=14, got %d", l.status)
+	}
+	total := l.status + l.project + l.context + l.activity
+	if l.showMessage {
+		total += l.message
+	}
+	if total != 80 {
+		t.Errorf("expected columns to sum to 80, got %d (status=%d project=%d context=%d activity=%d message=%d show=%v)",
+			total, l.status, l.project, l.context, l.activity, l.message, l.showMessage)
+	}
+}
+
+func TestCalcSessionLayout_VeryNarrowTerminal(t *testing.T) {
+	l := calcSessionLayout(55)
+
+	if l.showMessage {
+		t.Error("expected LAST MESSAGE column hidden at 55 cols")
+	}
+	total := l.status + l.project + l.context + l.activity
+	if total != 55 {
+		t.Errorf("expected columns to sum to 55, got %d", total)
+	}
+}
+
+func TestCalcSessionLayout_MinWidth(t *testing.T) {
+	l := calcSessionLayout(40)
+
+	if l.showMessage {
+		t.Error("expected LAST MESSAGE hidden at 40 cols")
+	}
+	// At tiny widths, project uses whatever space remains
+	expected := 40 - fixedStatusWidth - fixedContextWidth - fixedActivityWidth
+	if expected < 1 {
+		expected = 1
+	}
+	if l.project != expected {
+		t.Errorf("expected project=%d, got %d", expected, l.project)
+	}
+}
+
+func TestCalcHistoryLayout_WideTerminal(t *testing.T) {
+	l := calcHistoryLayout(120)
+
+	if !l.showContext {
+		t.Error("expected context column visible at 120 cols")
+	}
+	total := l.project + l.branch + l.duration + l.msgs + l.context
+	if total != 120 {
+		t.Errorf("expected columns to sum to 120, got %d", total)
+	}
+}
+
+func TestTruncate_NegativeMax(t *testing.T) {
+	result := truncate("hello world", -5)
+	if result != "" {
+		t.Errorf("expected empty string for negative max, got %q", result)
+	}
+}
+
+func TestTruncate_ZeroMax(t *testing.T) {
+	result := truncate("hello world", 0)
+	if result != "" {
+		t.Errorf("expected empty string for zero max, got %q", result)
+	}
+}
+
+func TestCalcHistoryLayout_NarrowTerminal(t *testing.T) {
+	l := calcHistoryLayout(60)
+
+	total := l.project + l.branch + l.duration + l.msgs
+	if l.showContext {
+		total += l.context
+	}
+	if total != 60 {
+		t.Errorf("expected columns to sum to 60, got %d", total)
+	}
+}

--- a/internal/ui/terminal.go
+++ b/internal/ui/terminal.go
@@ -1,0 +1,32 @@
+package ui
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const defaultTerminalWidth = 120
+
+// getTerminalWidth returns the current terminal width in columns.
+// Falls back to defaultTerminalWidth if detection fails.
+func getTerminalWidth() int {
+	var ws struct {
+		Row    uint16
+		Col    uint16
+		Xpixel uint16
+		Ypixel uint16
+	}
+
+	fd := os.Stdout.Fd()
+	_, _, err := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		fd,
+		uintptr(syscall.TIOCGWINSZ),
+		uintptr(unsafe.Pointer(&ws)),
+	)
+	if err != 0 || ws.Col == 0 {
+		return defaultTerminalWidth
+	}
+	return int(ws.Col)
+}


### PR DESCRIPTION
## Summary
- Detect terminal width at runtime using `TIOCGWINSZ` syscall (stdlib only, no new deps)
- Adapt column widths dynamically: fixed columns (STATUS, CONTEXT, LAST ACTIVITY) keep their size, flexible columns (PROJECT, LAST MESSAGE) share remaining space
- Hide LAST MESSAGE column entirely when the terminal is too narrow (<70 cols)
- Drop project suffixes (branch, indicators) gracefully when space is tight instead of panicking
- Fix `truncate()` to handle negative/zero max values safely (previously caused slice bounds panic on resize)
- Applied to all three views: live dashboard, list mode, and history

## Test plan
- [x] Unit tests for layout calculation at various terminal widths (wide, narrow, very narrow, minimum)
- [x] Unit tests for truncate with negative/zero max values
- [x] Manual testing: resize terminal while live view is running — no panic
- [x] Verified list mode output adapts to terminal width