### PR TITLE
Fix context reporting and move last message to separate line

### DIFF
--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -115,6 +115,85 @@ func TestExtractContextUsage(t *testing.T) {
 			wantTokens:     180100,
 			wantHasContext: true,
 		},
+		{
+			name: "compact_boundary after last assistant resets context",
+			entries: []LogEntry{
+				{
+					Type: "assistant",
+					Message: &Message{
+						Role:  "assistant",
+						Model: "claude-opus-4-6",
+						Usage: &Usage{
+							InputTokens:              100,
+							CacheCreationInputTokens: 10000,
+							CacheReadInputTokens:     170000,
+							OutputTokens:             1000,
+						},
+					},
+				},
+				{Type: "system", Subtype: "compact_boundary"},
+			},
+			wantPercent:    0,
+			wantTokens:     0,
+			wantHasContext: false,
+		},
+		{
+			name: "microcompact_boundary after last assistant resets context",
+			entries: []LogEntry{
+				{
+					Type: "assistant",
+					Message: &Message{
+						Role:  "assistant",
+						Model: "claude-opus-4-6",
+						Usage: &Usage{
+							InputTokens:              100,
+							CacheCreationInputTokens: 10000,
+							CacheReadInputTokens:     170000,
+							OutputTokens:             1000,
+						},
+					},
+				},
+				{Type: "system", Subtype: "microcompact_boundary"},
+			},
+			wantPercent:    0,
+			wantTokens:     0,
+			wantHasContext: false,
+		},
+		{
+			name: "assistant after compact_boundary returns correct usage",
+			entries: []LogEntry{
+				{
+					Type: "assistant",
+					Message: &Message{
+						Role:  "assistant",
+						Model: "claude-opus-4-6",
+						Usage: &Usage{
+							InputTokens:              100,
+							CacheCreationInputTokens: 10000,
+							CacheReadInputTokens:     170000,
+							OutputTokens:             1000,
+						},
+					},
+				},
+				{Type: "system", Subtype: "compact_boundary"},
+				{
+					Type: "assistant",
+					Message: &Message{
+						Role:  "assistant",
+						Model: "claude-opus-4-6",
+						Usage: &Usage{
+							InputTokens:              10,
+							CacheCreationInputTokens: 1000,
+							CacheReadInputTokens:     19000,
+							OutputTokens:             500,
+						},
+					},
+				},
+			},
+			wantPercent:    10.005, // (10 + 1000 + 19000) / 200000 * 100
+			wantTokens:     20010,
+			wantHasContext: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -5,9 +5,6 @@ import "testing"
 func TestCalcSessionLayout_WideTerminal(t *testing.T) {
 	l := calcSessionLayout(140)
 
-	if !l.showMessage {
-		t.Error("expected LAST MESSAGE column visible at 140 cols")
-	}
 	if l.status != 14 {
 		t.Errorf("expected status=14, got %d", l.status)
 	}
@@ -17,8 +14,12 @@ func TestCalcSessionLayout_WideTerminal(t *testing.T) {
 	if l.activity != 15 {
 		t.Errorf("expected activity=15, got %d", l.activity)
 	}
-	// project + message should use the remaining space
-	total := l.status + l.project + l.context + l.activity + l.message
+	// All remaining space goes to project
+	expectedProject := 140 - fixedStatusWidth - fixedContextWidth - fixedActivityWidth
+	if l.project != expectedProject {
+		t.Errorf("expected project=%d, got %d", expectedProject, l.project)
+	}
+	total := l.status + l.project + l.context + l.activity
 	if total != 140 {
 		t.Errorf("expected columns to sum to 140, got %d", total)
 	}
@@ -27,26 +28,19 @@ func TestCalcSessionLayout_WideTerminal(t *testing.T) {
 func TestCalcSessionLayout_NarrowTerminal(t *testing.T) {
 	l := calcSessionLayout(80)
 
-	// At 80 cols the LAST MESSAGE column should still be visible but narrow
 	if l.status != 14 {
 		t.Errorf("expected status=14, got %d", l.status)
 	}
 	total := l.status + l.project + l.context + l.activity
-	if l.showMessage {
-		total += l.message
-	}
 	if total != 80 {
-		t.Errorf("expected columns to sum to 80, got %d (status=%d project=%d context=%d activity=%d message=%d show=%v)",
-			total, l.status, l.project, l.context, l.activity, l.message, l.showMessage)
+		t.Errorf("expected columns to sum to 80, got %d (status=%d project=%d context=%d activity=%d)",
+			total, l.status, l.project, l.context, l.activity)
 	}
 }
 
 func TestCalcSessionLayout_VeryNarrowTerminal(t *testing.T) {
 	l := calcSessionLayout(55)
 
-	if l.showMessage {
-		t.Error("expected LAST MESSAGE column hidden at 55 cols")
-	}
 	total := l.status + l.project + l.context + l.activity
 	if total != 55 {
 		t.Errorf("expected columns to sum to 55, got %d", total)
@@ -56,9 +50,6 @@ func TestCalcSessionLayout_VeryNarrowTerminal(t *testing.T) {
 func TestCalcSessionLayout_MinWidth(t *testing.T) {
 	l := calcSessionLayout(40)
 
-	if l.showMessage {
-		t.Error("expected LAST MESSAGE hidden at 40 cols")
-	}
 	// At tiny widths, project uses whatever space remains
 	expected := 40 - fixedStatusWidth - fixedContextWidth - fixedActivityWidth
 	if expected < 1 {


### PR DESCRIPTION
## Summary
- **Fix stale context after restart/clear**: `findMostRecentLog` now returns empty files for fresh sessions instead of falling back to old logs. `extractContextUsage` respects `compact_boundary` and `microcompact_boundary` entries so context resets correctly after compaction.
- **Move last message to separate line**: The LAST MESSAGE column is removed from the table and instead rendered as an indented, dimmed second line below each session row, giving it the full terminal width.

## Test plan
- [x] Existing tests pass (`go test ./...`)
- [x] New tests for compact/microcompact boundary handling added and passing
- [x] Layout tests updated for new column structure
- [ ] Manual: start a fresh Claude session and verify context shows "-" instead of previous session data
- [ ] Manual: after a compact, verify context resets until next response
- [ ] Manual: verify last message appears on its own indented line in both `csm` and `csm -l`
- [ ] Manual: verify narrow terminals still render correctly