### PR TITLE
Fix context reset, message layout, and row wrapping

### DIFF
--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -21,6 +21,7 @@ type sessionLayout struct {
 // calcSessionLayout computes column widths for the given terminal width.
 // Fixed columns (status, context, activity) keep their size.
 // All remaining space goes to the project column.
+// Accounts for 3 separator spaces between the 4 columns.
 func calcSessionLayout(width int) sessionLayout {
 	l := sessionLayout{
 		status:   fixedStatusWidth,
@@ -28,14 +29,15 @@ func calcSessionLayout(width int) sessionLayout {
 		activity: fixedActivityWidth,
 	}
 
-	fixed := l.status + l.context + l.activity
+	const columnGaps = 3 // spaces between 4 columns
+	fixed := l.status + l.context + l.activity + columnGaps
 	remaining := width - fixed
 	if remaining < 1 {
 		remaining = 1
 	}
 	l.project = remaining
 
-	l.totalWidth = l.status + l.project + l.context + l.activity
+	l.totalWidth = l.status + l.project + l.context + l.activity + columnGaps
 
 	return l
 }

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -14,14 +14,13 @@ func TestCalcSessionLayout_WideTerminal(t *testing.T) {
 	if l.activity != 15 {
 		t.Errorf("expected activity=15, got %d", l.activity)
 	}
-	// All remaining space goes to project
-	expectedProject := 140 - fixedStatusWidth - fixedContextWidth - fixedActivityWidth
+	// All remaining space goes to project (minus 3 column gaps)
+	expectedProject := 140 - fixedStatusWidth - fixedContextWidth - fixedActivityWidth - 3
 	if l.project != expectedProject {
 		t.Errorf("expected project=%d, got %d", expectedProject, l.project)
 	}
-	total := l.status + l.project + l.context + l.activity
-	if total != 140 {
-		t.Errorf("expected columns to sum to 140, got %d", total)
+	if l.totalWidth != 140 {
+		t.Errorf("expected totalWidth=140, got %d", l.totalWidth)
 	}
 }
 
@@ -31,27 +30,25 @@ func TestCalcSessionLayout_NarrowTerminal(t *testing.T) {
 	if l.status != 14 {
 		t.Errorf("expected status=14, got %d", l.status)
 	}
-	total := l.status + l.project + l.context + l.activity
-	if total != 80 {
-		t.Errorf("expected columns to sum to 80, got %d (status=%d project=%d context=%d activity=%d)",
-			total, l.status, l.project, l.context, l.activity)
+	if l.totalWidth != 80 {
+		t.Errorf("expected totalWidth=80, got %d (status=%d project=%d context=%d activity=%d)",
+			l.totalWidth, l.status, l.project, l.context, l.activity)
 	}
 }
 
 func TestCalcSessionLayout_VeryNarrowTerminal(t *testing.T) {
 	l := calcSessionLayout(55)
 
-	total := l.status + l.project + l.context + l.activity
-	if total != 55 {
-		t.Errorf("expected columns to sum to 55, got %d", total)
+	if l.totalWidth != 55 {
+		t.Errorf("expected totalWidth=55, got %d", l.totalWidth)
 	}
 }
 
 func TestCalcSessionLayout_MinWidth(t *testing.T) {
 	l := calcSessionLayout(40)
 
-	// At tiny widths, project uses whatever space remains
-	expected := 40 - fixedStatusWidth - fixedContextWidth - fixedActivityWidth
+	// At tiny widths, project uses whatever space remains (minus 3 column gaps)
+	expected := 40 - fixedStatusWidth - fixedContextWidth - fixedActivityWidth - 3
 	if expected < 1 {
 		expected = 1
 	}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -318,19 +318,22 @@ func renderSessionRow(s session.Session, l sessionLayout, nl string) {
 		l.activity, elapsed)
 	fmt.Print(row + nl)
 
-	// Second line: indented last message
+	// Second line: last message aligned with status text (after "● ")
 	desc := s.LastMessage
 	if desc == "" {
 		desc = s.Task
 	}
 	if desc != "" && desc != "-" {
-		indent := l.status // align under project column
+		indent := 2 // align with status text (after symbol + space)
 		msgWidth := l.totalWidth - indent
 		if msgWidth > 0 {
 			msg := truncate(desc, msgWidth)
 			fmt.Printf("%s%s%s%s", strings.Repeat(" ", indent), Dim, msg, Reset+nl)
 		}
 	}
+
+	// Blank line after each session block for visual grouping
+	fmt.Print(nl)
 }
 
 // formatProject formats the project name with optional indicators, padded to maxLen visible chars


### PR DESCRIPTION
## Summary
- Reset context percentage after compact events so stale values don't persist
- Show last message on a separate line aligned with status text for better readability
- Fix session row wrapping caused by layout not accounting for column separator spaces
- Add blank line between session blocks for clear visual grouping

## Test plan
- [ ] Verify sessions with last messages display the message tightly under the main row
- [ ] Verify a blank line separates session blocks from each other
- [ ] Verify rows no longer wrap at various terminal widths
- [ ] Verify context resets to 0% after a compact event
- [ ] Run `go test ./...` to confirm all tests pass