### PR TITLE
fix: handle os.UserHomeDir error instead of ignoring it

### DIFF
--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -43,7 +43,10 @@ type IndexEntry struct {
 
 // DiscoverHistory finds all sessions from the past N days
 func DiscoverHistory(days int) ([]HistorySession, error) {
-	projectsDir := ClaudeProjectsDir()
+	projectsDir, err := ClaudeProjectsDir()
+	if err != nil {
+		return nil, err
+	}
 	cutoff := time.Now().AddDate(0, 0, -days)
 
 	var sessions []HistorySession

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -91,9 +91,12 @@ type BashToolInput struct {
 }
 
 // ClaudeProjectsDir returns the path to the Claude projects directory
-func ClaudeProjectsDir() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".claude", "projects")
+func ClaudeProjectsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".claude", "projects"), nil
 }
 
 // getRunningClaudeDirs returns a map of encoded directory names to PIDs where Claude processes are running
@@ -164,7 +167,10 @@ func isDesktopSession(projectName string) bool {
 
 // Discover finds all active Claude sessions
 func Discover() ([]Session, error) {
-	projectsDir := ClaudeProjectsDir()
+	projectsDir, err := ClaudeProjectsDir()
+	if err != nil {
+		return nil, err
+	}
 
 	entries, err := os.ReadDir(projectsDir)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Handle the error from `os.UserHomeDir()` in `ClaudeProjectsDir()` instead of silently ignoring it
- Propagate the error through `Discover()` and `DiscoverHistory()` callers
- Prevents silent fallback to a relative path when the home directory cannot be determined

Closes #2

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes
- [ ] Verify error message appears when HOME is unset: `HOME= go run . 2>&1`