### PR TITLE
Issue #14: Fix Needs Input status for auto-approved tools and show Now for active sessions

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -741,8 +741,14 @@ func determineStatus(entries []LogEntry, isRunning bool) (Status, string, bool) 
 		}
 	}
 
-	// If there's a pending tool_use, session is waiting for input (not ghost/idle)
+	// If there's a pending tool_use, check recency to decide status.
+	// Many tools (Task, Read, Grep, Write, Edit, etc.) are auto-approved and
+	// execute without user interaction. A recent pending tool_use likely means
+	// the tool is currently executing, not waiting for approval.
 	if hasPendingToolUse {
+		if lastAssistant != nil && time.Since(lastAssistant.Timestamp) < 2*time.Minute {
+			return StatusWorking, "Using: " + pendingToolName, false
+		}
 		return StatusNeedsInput, "Using: " + pendingToolName, false
 	}
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -314,13 +314,16 @@ func formatContext(s session.Session, width int) string {
 // The main row shows status, project, context, and activity.
 // A second indented line shows the last message using the full width.
 func renderSessionRow(s session.Session, l sessionLayout, nl string) {
-	elapsed := formatElapsed(time.Since(s.LastActivity))
+	activity := formatElapsed(time.Since(s.LastActivity))
+	if s.Status == session.StatusWorking {
+		activity = "Now"
+	}
 
 	row := fmt.Sprintf("%s %s %s %-*s",
 		formatStatus(s.Status, l.status),
 		formatProject(s, l.project),
 		formatContext(s, l.context),
-		l.activity, elapsed)
+		l.activity, activity)
 	fmt.Print(row + nl)
 
 	// Second line: last message aligned with status text (after "● ")

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -90,7 +90,7 @@
         sessionsList.innerHTML = currentSessions.map(s => {
             const cls = statusClass(s.status);
             const symbol = statusSymbol(s.status);
-            const age = formatAge(s.last_activity);
+            const age = s.status === 'Working' ? 'Now' : formatAge(s.last_activity);
             const pct = s.context_percent || 0;
             const ctxCls = pct > 90 ? 'high' : pct > 75 ? 'medium' : 'low';
 


### PR DESCRIPTION
## Summary
- Use a 2-minute recency heuristic for pending `tool_use` blocks: recent ones show **Working** (tool is executing), older ones show **Needs Input** (likely waiting for user approval)
- Display **"Now"** instead of elapsed time (e.g., "5s ago") for sessions with Working status in both terminal UI and web dashboard

## Changes
- `internal/session/session.go` — Added recency check in `determineStatus()` before classifying pending tool_use as NeedsInput
- `internal/ui/ui.go` — Show "Now" in activity column when status is Working
- `internal/web/static/app.js` — Show "Now" in web dashboard when status is Working

## Testing
- `go build ./...` compiles without errors
- `go test ./...` all tests pass

Fixes #14