### PR TITLE
Security hardening: headers, input validation, output sanitization

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -187,15 +187,25 @@ func ClaudeProjectsDir() (string, error) {
 func getRunningClaudeDirs() map[string]int {
 	dirs := make(map[string]int)
 
-	// Use ps to get Claude process IDs (more reliable than pgrep)
-	cmd := exec.Command("sh", "-c", "ps ax -o pid,comm | grep '[c]laude$' | awk '{print $1}'")
+	// Use ps directly without a shell pipeline to avoid shell injection risks
+	cmd := exec.Command("ps", "ax", "-o", "pid=,comm=")
 	output, err := cmd.Output()
 	if err != nil {
 		return dirs
 	}
 
-	pids := strings.Fields(string(output))
-	for _, pidStr := range pids {
+	// Parse ps output to find claude processes
+	for _, line := range bytes.Split(output, []byte("\n")) {
+		fields := bytes.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		comm := string(fields[len(fields)-1])
+		if !strings.HasSuffix(comm, "claude") {
+			continue
+		}
+
+		pidStr := string(fields[0])
 		pid := 0
 		fmt.Sscanf(pidStr, "%d", &pid)
 		if pid == 0 {
@@ -211,12 +221,12 @@ func getRunningClaudeDirs() map[string]int {
 
 		// Parse lsof output to find cwd
 		lines := bytes.Split(lsofOutput, []byte("\n"))
-		for _, line := range lines {
-			if bytes.Contains(line, []byte(" cwd ")) {
-				fields := bytes.Fields(line)
-				if len(fields) >= 9 {
+		for _, l := range lines {
+			if bytes.Contains(l, []byte(" cwd ")) {
+				lFields := bytes.Fields(l)
+				if len(lFields) >= 9 {
 					// Last field is the path
-					path := string(fields[len(fields)-1])
+					path := string(lFields[len(lFields)-1])
 					// Convert to encoded format (same as project directory names)
 					encoded := encodeProjectPath(path)
 					dirs[encoded] = pid
@@ -839,6 +849,17 @@ func FindGhostProcesses() ([]GhostProcess, error) {
 	return ghosts, nil
 }
 
+// isClaudeProcess checks whether the given PID belongs to a process named "claude".
+// This guards against PID reuse where a stale PID now belongs to an unrelated process.
+func isClaudeProcess(pid int) bool {
+	out, err := exec.Command("ps", "-p", fmt.Sprintf("%d", pid), "-o", "comm=").Output()
+	if err != nil {
+		return false
+	}
+	comm := strings.TrimSpace(string(out))
+	return strings.HasSuffix(comm, "claude")
+}
+
 // KillGhostProcesses terminates all ghost Claude processes
 // Returns the number of processes killed and any errors
 func KillGhostProcesses() ([]GhostProcess, error) {
@@ -849,6 +870,11 @@ func KillGhostProcesses() ([]GhostProcess, error) {
 
 	var killed []GhostProcess
 	for _, ghost := range ghosts {
+		// Verify the PID still belongs to a claude process (guards against PID reuse)
+		if !isClaudeProcess(ghost.PID) {
+			continue
+		}
+
 		// Send SIGTERM to gracefully terminate the process
 		process, err := os.FindProcess(ghost.PID)
 		if err != nil {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -327,9 +327,10 @@ func renderSessionRow(s session.Session, l sessionLayout, nl string) {
 	fmt.Print(row + nl)
 
 	// Second line: last message aligned with status text (after "● ")
-	desc := s.LastMessage
+	// Sanitize to prevent ANSI escape injection from log content
+	desc := sanitizeForTerminal(s.LastMessage)
 	if desc == "" {
-		desc = s.Task
+		desc = sanitizeForTerminal(s.Task)
 	}
 	if desc != "" && desc != "-" {
 		indent := 2 // align with status text (after symbol + space)
@@ -346,13 +347,14 @@ func renderSessionRow(s session.Session, l sessionLayout, nl string) {
 
 // formatProject formats the project name with optional indicators, padded to maxLen visible chars
 func formatProject(s session.Session, maxLen int) string {
-	name := s.Project
+	// Sanitize to prevent ANSI escape injection from log/filesystem content
+	name := sanitizeForTerminal(s.Project)
 	var suffixes []string
 	var suffixLens []int // visible length of each suffix (excluding space)
 
 	// Add git branch if present (show first, most useful)
 	if s.GitBranch != "" {
-		branch := s.GitBranch
+		branch := sanitizeForTerminal(s.GitBranch)
 		if len(branch) > 12 {
 			branch = branch[:12]
 		}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -13,7 +13,7 @@ import (
 func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(v); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
 	}
 }
 
@@ -27,7 +27,7 @@ func writeError(w http.ResponseWriter, msg string, code int) {
 func handleSessions(w http.ResponseWriter, r *http.Request) {
 	sessions, err := session.Discover()
 	if err != nil {
-		writeError(w, err.Error(), http.StatusInternalServerError)
+		writeError(w, "failed to discover sessions", http.StatusInternalServerError)
 		return
 	}
 	active := make([]session.Session, 0, len(sessions))
@@ -42,16 +42,20 @@ func handleSessions(w http.ResponseWriter, r *http.Request) {
 // handleHistory returns past sessions as JSON, merging index-based history
 // with inactive sessions from Discover() so they always appear somewhere.
 func handleHistory(w http.ResponseWriter, r *http.Request) {
+	const maxDays = 365
 	days := 7
 	if d := r.URL.Query().Get("days"); d != "" {
 		if parsed, err := strconv.Atoi(d); err == nil && parsed > 0 {
 			days = parsed
+			if days > maxDays {
+				days = maxDays
+			}
 		}
 	}
 
 	sessions, err := session.DiscoverHistory(days)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusInternalServerError)
+		writeError(w, "failed to load history", http.StatusInternalServerError)
 		return
 	}
 	if sessions == nil {
@@ -111,16 +115,20 @@ func handleTimeline(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	const maxLimit = 500
 	limit := 50
 	if l := r.URL.Query().Get("limit"); l != "" {
 		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
 			limit = parsed
+			if limit > maxLimit {
+				limit = maxLimit
+			}
 		}
 	}
 
 	entries, total, err := session.ParseTimeline(filePath, offset, limit)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, "failed to parse timeline", http.StatusBadRequest)
 		return
 	}
 
@@ -142,7 +150,7 @@ func handleMetrics(w http.ResponseWriter, r *http.Request) {
 
 	metrics, err := session.ParseMetrics(filePath)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, "failed to parse metrics", http.StatusBadRequest)
 		return
 	}
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -50,7 +50,7 @@ func (s *Server) Start(ctx context.Context) (<-chan error, error) {
 	addr := fmt.Sprintf("localhost:%d", s.port)
 	s.server = &http.Server{
 		Addr:    addr,
-		Handler: mux,
+		Handler: securityHeaders(mux),
 	}
 
 	// Start SSE hub
@@ -77,6 +77,18 @@ func (s *Server) Start(ctx context.Context) (<-chan error, error) {
 	}()
 
 	return errCh, nil
+}
+
+// securityHeaders wraps an http.Handler to set standard security headers
+// on every response.
+func securityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		w.Header().Set("Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'")
+		next.ServeHTTP(w, r)
+	})
 }
 
 // Addr returns the address the server is configured to listen on.

--- a/internal/web/sse.go
+++ b/internal/web/sse.go
@@ -1,9 +1,9 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -74,14 +74,29 @@ func (h *SSEHub) Run(ctx context.Context) {
 			if err != nil {
 				continue
 			}
-			msg := fmt.Appendf(nil, "event: sessions\ndata: %s\n\n", data)
-			h.broadcast(msg)
+			h.broadcast(formatSSE("sessions", data))
 
 		case <-heartbeat.C:
-			msg := []byte("event: heartbeat\ndata: {}\n\n")
-			h.broadcast(msg)
+			h.broadcast(formatSSE("heartbeat", []byte("{}")))
 		}
 	}
+}
+
+// formatSSE formats an SSE message safely. If data contains literal newlines
+// (which json.Marshal should not produce, but as defense-in-depth), each line
+// gets its own "data:" prefix per the SSE specification.
+func formatSSE(event string, data []byte) []byte {
+	var buf bytes.Buffer
+	buf.WriteString("event: ")
+	buf.WriteString(event)
+	buf.WriteByte('\n')
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		buf.WriteString("data: ")
+		buf.Write(line)
+		buf.WriteByte('\n')
+	}
+	buf.WriteByte('\n')
+	return buf.Bytes()
 }
 
 func (h *SSEHub) broadcast(msg []byte) {
@@ -124,7 +139,7 @@ func (h *SSEHub) HandleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 		data, err := json.Marshal(active)
 		if err == nil {
-			fmt.Fprintf(w, "event: sessions\ndata: %s\n\n", data)
+			w.Write(formatSSE("sessions", data))
 			flusher.Flush()
 		}
 	}


### PR DESCRIPTION
## Summary
Addresses multiple security findings from a comprehensive audit of the codebase.

- Add HTTP security headers middleware (X-Content-Type-Options, X-Frame-Options, CSP, Referrer-Policy)
- Sanitize web API error responses to prevent leaking internal file paths
- Cap `days` (max 365) and `limit` (max 500) query parameters to prevent resource exhaustion
- Verify PID belongs to a `claude` process before killing ghosts (guards against PID reuse)
- Sanitize all terminal output from log content to prevent ANSI escape injection
- Replace `sh -c` shell pipeline with direct `exec.Command` calls to eliminate shell metacharacter risks
- Add SSE `formatSSE()` helper with proper multi-line `data:` prefix handling per spec

## Changes
- `internal/web/server.go` — Security headers middleware wrapping all routes
- `internal/web/handlers.go` — Generic error messages, input bounds on `days` and `limit`
- `internal/web/sse.go` — `formatSSE()` helper replacing raw string formatting
- `internal/session/session.go` — Direct `ps` execution without shell, `isClaudeProcess()` PID validation
- `internal/ui/ui.go` — `sanitizeForTerminal()` applied to project, branch, message fields

## Testing
- `go build ./...` compiles without errors
- `go test ./...` all tests pass