### PR TITLE
fix: sign cross-compiled csm binary before app codesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Menu bar app amd64 build failing due to unsigned cross-compiled `csm` binary inside `.app` bundle
 - Menu bar app shows error message when `csm` binary is not found instead of generic "No sessions found"
 - Removed empty `AppDelegate` class and duplicate `.gitignore` entry
 - README now correctly references `--web-only` flag for menu bar app

--- a/macos/CSMMenuBar/Makefile
+++ b/macos/CSMMenuBar/Makefile
@@ -25,6 +25,7 @@ app: build-release
 	cp .build/release/CSMMenuBar $(APP_DIR)/Contents/MacOS/
 	cp .build/release/csm $(APP_DIR)/Contents/MacOS/
 	sed 's/1.0.0/$(VERSION)/' Sources/Info.plist > $(APP_DIR)/Contents/Info.plist
+	codesign --force --sign - $(APP_DIR)/Contents/MacOS/csm
 	codesign --force --sign - $(APP_DIR)
 
 clean:


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions release-menubar job failing on amd64 build due to unsigned cross-compiled Go binary inside the .app bundle. The codesign step now signs the csm binary individually before attempting to sign the entire .app bundle.

## Changes

- Added explicit codesign step for the csm binary in the Makefile app target
- Updated CHANGELOG.md with the fix

🤖 Generated with Claude Code