### PR TITLE
fix: use model-specific context window sizes for accurate percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Context percentage now uses model-specific context window sizes (Opus 4.6 and Sonnet 4.6 use 1M, others use 200K)
+
 ### Added
 
 - Detect multiple concurrent Claude sessions in the same project directory (each shown as a separate row/card)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -771,9 +771,9 @@ const DefaultContextWindow = 200000
 // Opus 4.6 and Sonnet 4.6 have 1M context windows; all others default to 200K.
 func contextWindowForModel(model string) int {
 	switch {
-	case strings.Contains(model, "opus-4-6") || model == "opus":
+	case strings.Contains(model, "opus-4-6"):
 		return 1_000_000
-	case strings.Contains(model, "sonnet-4-6") || model == "sonnet":
+	case strings.Contains(model, "sonnet-4-6"):
 		return 1_000_000
 	default:
 		return DefaultContextWindow

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -681,7 +681,8 @@ func extractContextUsage(entries []LogEntry) (float64, int) {
 			continue
 		}
 
-		percent := float64(totalTokens) / float64(DefaultContextWindow) * 100
+		window := contextWindowForModel(entry.Message.Model)
+		percent := float64(totalTokens) / float64(window) * 100
 		return percent, totalTokens
 	}
 
@@ -763,8 +764,21 @@ func readLastEntries(filePath string, count int) ([]LogEntry, error) {
 	return entries, scanner.Err()
 }
 
-// DefaultContextWindow is the context window size for Claude models (200K tokens)
+// DefaultContextWindow is the fallback context window size for Claude models (200K tokens)
 const DefaultContextWindow = 200000
+
+// contextWindowForModel returns the context window size for a given model ID.
+// Opus 4.6 and Sonnet 4.6 have 1M context windows; all others default to 200K.
+func contextWindowForModel(model string) int {
+	switch {
+	case strings.Contains(model, "opus-4-6") || model == "opus":
+		return 1_000_000
+	case strings.Contains(model, "sonnet-4-6") || model == "sonnet":
+		return 1_000_000
+	default:
+		return DefaultContextWindow
+	}
+}
 
 // GhostThreshold is the duration after which a running process with no log activity
 // is considered a ghost (orphaned) process

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -245,9 +245,9 @@ func TestContextWindowForModel(t *testing.T) {
 		want  int
 	}{
 		{"claude-opus-4-6", 1_000_000},
-		{"opus", 1_000_000},
+		{"opus", 200_000},
 		{"claude-sonnet-4-6", 1_000_000},
-		{"sonnet", 1_000_000},
+		{"sonnet", 200_000},
 		{"claude-haiku-4-5-20251001", 200_000},
 		{"haiku", 200_000},
 		{"claude-sonnet-4-5-20250929", 200_000},

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -55,7 +55,7 @@ func TestExtractContextUsage(t *testing.T) {
 					},
 				},
 			},
-			wantPercent:    10.255, // (10 + 1000 + 19000 + 500) / 200000 * 100
+			wantPercent:    2.051, // (10 + 1000 + 19000 + 500) / 1000000 * 100 (opus-4-6 = 1M)
 			wantTokens:     20510,
 			wantHasContext: true,
 		},
@@ -90,7 +90,7 @@ func TestExtractContextUsage(t *testing.T) {
 					},
 				},
 			},
-			wantPercent:    20.105, // (10 + 1000 + 39000 + 200) / 200000 * 100
+			wantPercent:    4.021, // (10 + 1000 + 39000 + 200) / 1000000 * 100 (opus-4-6 = 1M)
 			wantTokens:     40210,
 			wantHasContext: true,
 		},
@@ -111,7 +111,7 @@ func TestExtractContextUsage(t *testing.T) {
 					},
 				},
 			},
-			wantPercent:    90.55, // (100 + 10000 + 170000 + 1000) / 200000 * 100
+			wantPercent:    18.11, // (100 + 10000 + 170000 + 1000) / 1000000 * 100 (opus-4-6 = 1M)
 			wantTokens:     181100,
 			wantHasContext: true,
 		},
@@ -190,7 +190,28 @@ func TestExtractContextUsage(t *testing.T) {
 					},
 				},
 			},
-			wantPercent:    10.255, // (10 + 1000 + 19000 + 500) / 200000 * 100
+			wantPercent:    2.051, // (10 + 1000 + 19000 + 500) / 1000000 * 100 (opus-4-6 = 1M)
+			wantTokens:     20510,
+			wantHasContext: true,
+		},
+		{
+			name: "haiku uses 200K context window",
+			entries: []LogEntry{
+				{
+					Type: "assistant",
+					Message: &Message{
+						Role:  "assistant",
+						Model: "claude-haiku-4-5-20251001",
+						Usage: &Usage{
+							InputTokens:              10,
+							CacheCreationInputTokens: 1000,
+							CacheReadInputTokens:     19000,
+							OutputTokens:             500,
+						},
+					},
+				},
+			},
+			wantPercent:    10.255, // (10 + 1000 + 19000 + 500) / 200000 * 100 (haiku = 200K)
 			wantTokens:     20510,
 			wantHasContext: true,
 		},
@@ -213,6 +234,32 @@ func TestExtractContextUsage(t *testing.T) {
 			diff := percent - tt.wantPercent
 			if diff < -0.01 || diff > 0.01 {
 				t.Errorf("percent = %f, want %f", percent, tt.wantPercent)
+			}
+		})
+	}
+}
+
+func TestContextWindowForModel(t *testing.T) {
+	tests := []struct {
+		model string
+		want  int
+	}{
+		{"claude-opus-4-6", 1_000_000},
+		{"opus", 1_000_000},
+		{"claude-sonnet-4-6", 1_000_000},
+		{"sonnet", 1_000_000},
+		{"claude-haiku-4-5-20251001", 200_000},
+		{"haiku", 200_000},
+		{"claude-sonnet-4-5-20250929", 200_000},
+		{"", 200_000},
+		{"unknown-model", 200_000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			got := contextWindowForModel(tt.model)
+			if got != tt.want {
+				t.Errorf("contextWindowForModel(%q) = %d, want %d", tt.model, got, tt.want)
 			}
 		})
 	}

--- a/internal/session/timeline.go
+++ b/internal/session/timeline.go
@@ -170,6 +170,7 @@ func parseMetricsInternal(logFile string) (*SessionMetrics, error) {
 	scanner.Buffer(buf, 10*1024*1024)
 
 	var lastUsage *Usage
+	var lastUsageModel string
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -212,6 +213,7 @@ func parseMetricsInternal(logFile string) (*SessionMetrics, error) {
 					m.TotalCacheCreationTokens += u.CacheCreationInputTokens
 					m.TotalCacheReadTokens += u.CacheReadInputTokens
 					lastUsage = u
+					lastUsageModel = entry.Message.Model
 				}
 
 				// Count tool usage
@@ -240,7 +242,8 @@ func parseMetricsInternal(logFile string) (*SessionMetrics, error) {
 	if lastUsage != nil {
 		totalTokens := lastUsage.InputTokens + lastUsage.CacheCreationInputTokens + lastUsage.CacheReadInputTokens + lastUsage.OutputTokens
 		m.ContextTokens = totalTokens
-		m.ContextPercent = float64(totalTokens) / float64(DefaultContextWindow) * 100
+		window := contextWindowForModel(lastUsageModel)
+		m.ContextPercent = float64(totalTokens) / float64(window) * 100
 	}
 
 	return m, nil

--- a/internal/session/timeline.go
+++ b/internal/session/timeline.go
@@ -230,6 +230,8 @@ func parseMetricsInternal(logFile string) (*SessionMetrics, error) {
 			}
 			if entry.Subtype == "compact_boundary" || entry.Subtype == "microcompact_boundary" {
 				m.CompactCount++
+				lastUsage = nil
+				lastUsageModel = ""
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Context percentage was calculated using a hardcoded 200K denominator, but Opus 4.6 and Sonnet 4.6 have 1M context windows
- Added `contextWindowForModel()` that maps model IDs to their actual context window sizes
- Opus 4.6 / Sonnet 4.6 → 1M, Haiku / older models / unknown → 200K
- Updated both `extractContextUsage` (session.go) and `parseMetricsInternal` (timeline.go)

## Test plan
- [x] All existing tests updated and passing with new expected percentages
- [x] New `TestContextWindowForModel` test covers all model ID patterns
- [x] New test case for Haiku verifying 200K context window
- [ ] Manual: run `csm` and verify Opus 4.6 sessions show ~5x lower context % than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)