### PR TITLE
feat: add Linux support and improve project naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Linux process detection via `/proc/<pid>/cwd` — live session status now works correctly on Linux without requiring `lsof`
+- Project naming from `cwd` field in JSONL logs — accurate, lossless project names on all platforms (replaces heuristic decoding of encoded directory names)
+- Session title display — custom titles set by Claude Code are shown in both TUI and web dashboard
+- Parse `cwd`, `customTitle`, and `slug` fields from Claude Code JSONL log entries
+- Linux manual install instructions in README
+
 ### Fixed
 
+- Project names on Linux paths (`/home/user/...`) now display correctly instead of falling back to an ugly slash-separated dump
+- Port conflict error message now suggests `ss -tlnp` on Linux instead of macOS-only `lsof -i`
 - Sessions actively using tools, hooks, or subagents no longer flicker to "Waiting" — progress heartbeats from Claude Code logs are now tracked
 - Multi-tool_use detection: all tool calls in an assistant message are now checked, not just the first
 - Extended assistant "Working" window from 30 seconds to 2 minutes to reduce false "Waiting" during brief log gaps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Linux process detection via `/proc/<pid>/cwd` — live session status now works correctly on Linux without requiring `lsof`
 - Project naming from `cwd` field in JSONL logs — accurate, lossless project names on all platforms (replaces heuristic decoding of encoded directory names)
 - Session title display — custom titles set by Claude Code are shown in both TUI and web dashboard
-- Parse `cwd`, `customTitle`, and `slug` fields from Claude Code JSONL log entries
+- Parse `cwd` and `customTitle` fields from Claude Code JSONL log entries
 - Linux manual install instructions in README
+- Path markers for project naming: `/repos/`, `/src/`, `/code/`, `/workspace/` in addition to `/Projects/`
 
 ### Fixed
 
+- Session title and cwd now extracted via full-file scan (`QuickSessionStats`) for both active and history views, ensuring consistency and finding titles set early in long sessions
+- Project names on Linux `/home/<user>/` paths now skip the home prefix for cleaner display (e.g., `repos/myproject` instead of `home/user/repos/myproject`)
+- UTF-8 safe truncation in TUI — branch names, session titles, and project names with multi-byte characters are no longer split mid-character
+- Removed hardcoded `max-width: 200px` on session title in web dashboard; flexbox layout handles overflow responsively
 - Project names on Linux paths (`/home/user/...`) now display correctly instead of falling back to an ugly slash-separated dump
 - Port conflict error message now suggests `ss -tlnp` on Linux instead of macOS-only `lsof -i`
 - Sessions actively using tools, hooks, or subagents no longer flicker to "Waiting" — progress heartbeats from Claude Code logs are now tracked

--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ brew install --cask yepzdk/tools/csm-menubar
 
 Download the latest binary from [Releases](https://github.com/yepzdk/claude-sessions-monitor/releases) and add to your PATH.
 
+**Linux (quick install):**
+
+```bash
+# amd64
+curl -L https://github.com/yepzdk/claude-sessions-monitor/releases/latest/download/csm-linux-amd64 -o csm
+chmod +x csm
+sudo mv csm /usr/local/bin/
+
+# arm64
+curl -L https://github.com/yepzdk/claude-sessions-monitor/releases/latest/download/csm-linux-arm64 -o csm
+chmod +x csm
+sudo mv csm /usr/local/bin/
+```
+
+**macOS:** Use Homebrew (above) or download `csm-darwin-amd64` / `csm-darwin-arm64` from releases.
+
 ### Build from source
 
 ```bash

--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -154,7 +154,7 @@ func DiscoverHistory(days int) ([]HistorySession, error) {
 				continue
 			}
 
-			msgCount, startTime, endTime, branch, prompt := QuickSessionStats(logFile)
+			msgCount, startTime, endTime, branch, prompt, sessionCwd := QuickSessionStats(logFile)
 			if startTime.IsZero() {
 				startTime = info.ModTime()
 			}
@@ -167,8 +167,14 @@ func DiscoverHistory(days int) ([]HistorySession, error) {
 				continue
 			}
 
+			// Use cwd for accurate project naming when available
+			displayName := projectName
+			if sessionCwd != "" {
+				displayName = extractProjectName(sessionCwd)
+			}
+
 			sessions = append(sessions, HistorySession{
-				Project:      projectName,
+				Project:      displayName,
 				GitBranch:    branch,
 				FirstPrompt:  prompt,
 				StartTime:    startTime,
@@ -221,12 +227,12 @@ func extractProjectName(fullPath string) string {
 }
 
 // QuickSessionStats does a fast scan of a JSONL log file to get the message
-// count, time range, git branch, and first user prompt without full JSON
+// count, time range, git branch, cwd, and first user prompt without full JSON
 // parsing of every line.
-func QuickSessionStats(logFile string) (messageCount int, startTime, endTime time.Time, gitBranch, firstPrompt string) {
+func QuickSessionStats(logFile string) (messageCount int, startTime, endTime time.Time, gitBranch, firstPrompt, cwd string) {
 	file, err := os.Open(logFile)
 	if err != nil {
-		return 0, time.Time{}, time.Time{}, "", ""
+		return 0, time.Time{}, time.Time{}, "", "", ""
 	}
 	defer file.Close()
 
@@ -255,6 +261,13 @@ func QuickSessionStats(logFile string) (messageCount int, startTime, endTime tim
 			gitBranch = b
 		}
 
+		// Extract cwd (use first non-empty value, stays constant within a session)
+		if cwd == "" {
+			if c := extractStringField(line, `"cwd":"`); c != "" {
+				cwd = c
+			}
+		}
+
 		// Extract timestamp via string matching (avoids full JSON parse)
 		if ts := extractTimestampFromLine(line); !ts.IsZero() {
 			if startTime.IsZero() {
@@ -264,7 +277,7 @@ func QuickSessionStats(logFile string) (messageCount int, startTime, endTime tim
 		}
 	}
 
-	return messageCount, startTime, endTime, gitBranch, firstPrompt
+	return messageCount, startTime, endTime, gitBranch, firstPrompt, cwd
 }
 
 // extractStringField extracts a JSON string value using fast string matching.

--- a/internal/session/history.go
+++ b/internal/session/history.go
@@ -154,7 +154,7 @@ func DiscoverHistory(days int) ([]HistorySession, error) {
 				continue
 			}
 
-			msgCount, startTime, endTime, branch, prompt, sessionCwd := QuickSessionStats(logFile)
+			msgCount, startTime, endTime, branch, prompt, sessionCwd, _ := QuickSessionStats(logFile)
 			if startTime.IsZero() {
 				startTime = info.ModTime()
 			}
@@ -212,12 +212,27 @@ func parseSessionIndex(path string) ([]IndexEntry, error) {
 
 // extractProjectName extracts a readable project name from a full path
 func extractProjectName(fullPath string) string {
-	// /Users/username/Projects/org/project -> org/project
-	if idx := strings.Index(fullPath, "/Projects/"); idx != -1 {
-		return fullPath[idx+len("/Projects/"):]
+	// Try well-known directory markers (most specific first)
+	markers := []string{"/Projects/", "/repos/", "/src/", "/code/", "/workspace/"}
+	for _, marker := range markers {
+		if idx := strings.Index(fullPath, marker); idx != -1 {
+			return fullPath[idx+len(marker):]
+		}
 	}
 
-	// Fallback: just use the last two path components
+	// Detect /home/<user>/X pattern: skip the home directory prefix
+	if strings.HasPrefix(fullPath, "/home/") {
+		// /home/user/repos/myproject -> repos/myproject
+		rest := fullPath[len("/home/"):]
+		if slashIdx := strings.Index(rest, "/"); slashIdx != -1 {
+			afterUser := rest[slashIdx+1:]
+			if afterUser != "" {
+				return afterUser
+			}
+		}
+	}
+
+	// Fallback: last two path components
 	parts := strings.Split(fullPath, "/")
 	if len(parts) >= 2 {
 		return parts[len(parts)-2] + "/" + parts[len(parts)-1]
@@ -227,12 +242,12 @@ func extractProjectName(fullPath string) string {
 }
 
 // QuickSessionStats does a fast scan of a JSONL log file to get the message
-// count, time range, git branch, cwd, and first user prompt without full JSON
-// parsing of every line.
-func QuickSessionStats(logFile string) (messageCount int, startTime, endTime time.Time, gitBranch, firstPrompt, cwd string) {
+// count, time range, git branch, cwd, first user prompt, and custom title
+// without full JSON parsing of every line.
+func QuickSessionStats(logFile string) (messageCount int, startTime, endTime time.Time, gitBranch, firstPrompt, cwd, customTitle string) {
 	file, err := os.Open(logFile)
 	if err != nil {
-		return 0, time.Time{}, time.Time{}, "", "", ""
+		return 0, time.Time{}, time.Time{}, "", "", "", ""
 	}
 	defer file.Close()
 
@@ -268,6 +283,11 @@ func QuickSessionStats(logFile string) (messageCount int, startTime, endTime tim
 			}
 		}
 
+		// Extract custom title (keep last non-empty value, title can change mid-session)
+		if t := extractStringField(line, `"customTitle":"`); t != "" {
+			customTitle = t
+		}
+
 		// Extract timestamp via string matching (avoids full JSON parse)
 		if ts := extractTimestampFromLine(line); !ts.IsZero() {
 			if startTime.IsZero() {
@@ -277,7 +297,7 @@ func QuickSessionStats(logFile string) (messageCount int, startTime, endTime tim
 		}
 	}
 
-	return messageCount, startTime, endTime, gitBranch, firstPrompt, cwd
+	return messageCount, startTime, endTime, gitBranch, firstPrompt, cwd, customTitle
 }
 
 // extractStringField extracts a JSON string value using fast string matching.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"syscall"
@@ -42,6 +43,7 @@ type Session struct {
 	HasUnsandboxed bool      `json:"has_unsandboxed,omitempty"` // True if any command bypassed sandbox
 	ContextPercent float64   `json:"context_percent,omitempty"` // Percentage of context window used
 	ContextTokens  int       `json:"context_tokens,omitempty"`  // Total input tokens from last usage entry
+	SessionTitle   string    `json:"session_title,omitempty"`   // Custom title set by user/Claude
 }
 
 // RunningProcess represents a Claude process with its PID and working directory
@@ -52,12 +54,15 @@ type RunningProcess struct {
 
 // LogEntry represents a single line in the JSONL log
 type LogEntry struct {
-	Type      string    `json:"type"`
-	Subtype   string    `json:"subtype,omitempty"`
-	Timestamp time.Time `json:"timestamp"`
-	Message   *Message  `json:"message,omitempty"`
-	Summary   string    `json:"summary,omitempty"` // For type: "summary" entries
-	GitBranch string    `json:"gitBranch,omitempty"`
+	Type        string    `json:"type"`
+	Subtype     string    `json:"subtype,omitempty"`
+	Timestamp   time.Time `json:"timestamp"`
+	Message     *Message  `json:"message,omitempty"`
+	Summary     string    `json:"summary,omitempty"` // For type: "summary" entries
+	GitBranch   string    `json:"gitBranch,omitempty"`
+	CWD         string    `json:"cwd,omitempty"`         // Working directory of the Claude process
+	CustomTitle string    `json:"customTitle,omitempty"`  // User/Claude-set session title
+	Slug        string    `json:"slug,omitempty"`         // Session slug (e.g. "silly-questing-wirth")
 }
 
 // Message represents the message field in a log entry
@@ -214,30 +219,44 @@ func getRunningClaudeDirs() map[string][]int {
 			continue
 		}
 
-		// Get cwd for each process using lsof
-		lsofCmd := exec.Command("lsof", "-p", pidStr)
-		lsofOutput, err := lsofCmd.Output()
-		if err != nil {
+		// Get cwd for each process
+		path, err := getProcessCwd(pid)
+		if err != nil || path == "" {
 			continue
 		}
-
-		// Parse lsof output to find cwd
-		lines := bytes.Split(lsofOutput, []byte("\n"))
-		for _, l := range lines {
-			if bytes.Contains(l, []byte(" cwd ")) {
-				lFields := bytes.Fields(l)
-				if len(lFields) >= 9 {
-					// Last field is the path
-					path := string(lFields[len(lFields)-1])
-					// Convert to encoded format (same as project directory names)
-					encoded := encodeProjectPath(path)
-					dirs[encoded] = append(dirs[encoded], pid)
-				}
-			}
-		}
+		// Convert to encoded format (same as project directory names)
+		encoded := encodeProjectPath(path)
+		dirs[encoded] = append(dirs[encoded], pid)
 	}
 
 	return dirs
+}
+
+// getProcessCwd returns the current working directory of a process by PID.
+// On Linux it reads /proc/<pid>/cwd; on Darwin it uses lsof.
+func getProcessCwd(pid int) (string, error) {
+	if runtime.GOOS == "linux" {
+		return os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
+	}
+
+	// Darwin: use lsof to find cwd
+	pidStr := fmt.Sprintf("%d", pid)
+	lsofCmd := exec.Command("lsof", "-p", pidStr)
+	lsofOutput, err := lsofCmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	lines := bytes.Split(lsofOutput, []byte("\n"))
+	for _, l := range lines {
+		if bytes.Contains(l, []byte(" cwd ")) {
+			lFields := bytes.Fields(l)
+			if len(lFields) >= 9 {
+				return string(lFields[len(lFields)-1]), nil
+			}
+		}
+	}
+	return "", fmt.Errorf("cwd not found in lsof output for pid %d", pid)
 }
 
 // encodeProjectPath converts a filesystem path to the encoded directory name format
@@ -515,6 +534,21 @@ func parseSession(projectName, logFile string, pids []int) (Session, error) {
 
 	if len(entries) == 0 {
 		return session, nil
+	}
+
+	// Use cwd from log entries for accurate project naming (works on all platforms)
+	for _, e := range entries {
+		if e.CWD != "" {
+			session.Project = extractProjectName(e.CWD)
+			break
+		}
+	}
+
+	// Extract custom session title if set
+	for _, e := range entries {
+		if e.Type == "custom-title" && e.CustomTitle != "" {
+			session.SessionTitle = e.CustomTitle
+		}
 	}
 
 	// Extract summary from the log file (scans entire file)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -62,7 +62,6 @@ type LogEntry struct {
 	GitBranch   string    `json:"gitBranch,omitempty"`
 	CWD         string    `json:"cwd,omitempty"`         // Working directory of the Claude process
 	CustomTitle string    `json:"customTitle,omitempty"`  // User/Claude-set session title
-	Slug        string    `json:"slug,omitempty"`         // Session slug (e.g. "silly-questing-wirth")
 }
 
 // Message represents the message field in a log entry
@@ -234,6 +233,9 @@ func getRunningClaudeDirs() map[string][]int {
 
 // getProcessCwd returns the current working directory of a process by PID.
 // On Linux it reads /proc/<pid>/cwd; on Darwin it uses lsof.
+// Note: on Linux, reading /proc/<pid>/cwd requires the caller to be the same
+// user as the target process (or root). If csm runs as a different user,
+// os.Readlink will return a permission error and the process will be skipped.
 func getProcessCwd(pid int) (string, error) {
 	if runtime.GOOS == "linux" {
 		return os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
@@ -536,19 +538,14 @@ func parseSession(projectName, logFile string, pids []int) (Session, error) {
 		return session, nil
 	}
 
-	// Use cwd from log entries for accurate project naming (works on all platforms)
-	for _, e := range entries {
-		if e.CWD != "" {
-			session.Project = extractProjectName(e.CWD)
-			break
-		}
+	// Use QuickSessionStats for metadata that needs a full-file scan (cwd and title
+	// may appear early in the file, outside the last-100-entries window)
+	_, _, _, _, _, sessionCwd, sessionTitle := QuickSessionStats(logFile)
+	if sessionCwd != "" {
+		session.Project = extractProjectName(sessionCwd)
 	}
-
-	// Extract custom session title if set
-	for _, e := range entries {
-		if e.Type == "custom-title" && e.CustomTitle != "" {
-			session.SessionTitle = e.CustomTitle
-		}
+	if sessionTitle != "" {
+		session.SessionTitle = sessionTitle
 	}
 
 	// Extract summary from the log file (scans entire file)

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -267,17 +267,14 @@ func TestContextWindowForModel(t *testing.T) {
 }
 
 func TestLogEntryNewFields(t *testing.T) {
-	// Test that cwd, customTitle, and slug fields parse from JSONL
-	raw := `{"type":"user","timestamp":"2025-01-01T00:00:00Z","cwd":"/home/user/projects/myapp","slug":"silly-questing-wirth"}`
+	// Test that cwd and customTitle fields parse from JSONL
+	raw := `{"type":"user","timestamp":"2025-01-01T00:00:00Z","cwd":"/home/user/projects/myapp"}`
 	var entry LogEntry
 	if err := json.Unmarshal([]byte(raw), &entry); err != nil {
 		t.Fatalf("Failed to parse: %v", err)
 	}
 	if entry.CWD != "/home/user/projects/myapp" {
 		t.Errorf("CWD = %q, want %q", entry.CWD, "/home/user/projects/myapp")
-	}
-	if entry.Slug != "silly-questing-wirth" {
-		t.Errorf("Slug = %q, want %q", entry.Slug, "silly-questing-wirth")
 	}
 
 	// Test custom-title entry
@@ -344,9 +341,9 @@ func TestExtractProjectName(t *testing.T) {
 			want: "org/project",
 		},
 		{
-			name: "Linux home path",
+			name: "Linux home path with repos marker",
 			path: "/home/user/repos/myproject",
-			want: "repos/myproject",
+			want: "myproject",
 		},
 		{
 			name: "Linux with Projects",
@@ -354,9 +351,34 @@ func TestExtractProjectName(t *testing.T) {
 			want: "work/myapp",
 		},
 		{
-			name: "two components",
-			path: "/repos/myproject",
-			want: "repos/myproject",
+			name: "Linux home with nested path",
+			path: "/home/user/myproject",
+			want: "myproject",
+		},
+		{
+			name: "repos marker",
+			path: "/opt/repos/org/myapp",
+			want: "org/myapp",
+		},
+		{
+			name: "src marker",
+			path: "/var/src/backend-api",
+			want: "backend-api",
+		},
+		{
+			name: "code marker",
+			path: "/home/dev/code/org/tool",
+			want: "org/tool",
+		},
+		{
+			name: "workspace marker",
+			path: "/mnt/workspace/project-x",
+			want: "project-x",
+		},
+		{
+			name: "two components fallback",
+			path: "/opt/myproject",
+			want: "opt/myproject",
 		},
 	}
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -266,6 +266,110 @@ func TestContextWindowForModel(t *testing.T) {
 	}
 }
 
+func TestLogEntryNewFields(t *testing.T) {
+	// Test that cwd, customTitle, and slug fields parse from JSONL
+	raw := `{"type":"user","timestamp":"2025-01-01T00:00:00Z","cwd":"/home/user/projects/myapp","slug":"silly-questing-wirth"}`
+	var entry LogEntry
+	if err := json.Unmarshal([]byte(raw), &entry); err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+	if entry.CWD != "/home/user/projects/myapp" {
+		t.Errorf("CWD = %q, want %q", entry.CWD, "/home/user/projects/myapp")
+	}
+	if entry.Slug != "silly-questing-wirth" {
+		t.Errorf("Slug = %q, want %q", entry.Slug, "silly-questing-wirth")
+	}
+
+	// Test custom-title entry
+	raw2 := `{"type":"custom-title","customTitle":"add-linux-support","sessionId":"abc-123"}`
+	var entry2 LogEntry
+	if err := json.Unmarshal([]byte(raw2), &entry2); err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+	if entry2.Type != "custom-title" {
+		t.Errorf("Type = %q, want %q", entry2.Type, "custom-title")
+	}
+	if entry2.CustomTitle != "add-linux-support" {
+		t.Errorf("CustomTitle = %q, want %q", entry2.CustomTitle, "add-linux-support")
+	}
+}
+
+func TestDecodeProjectName(t *testing.T) {
+	tests := []struct {
+		name string
+		input string
+		want string
+	}{
+		{
+			name:  "macOS with Projects marker",
+			input: "-Users-jesperpedersen-Projects-personal-claude-sessions-monitor",
+			want:  "personal/claude-sessions-monitor",
+		},
+		{
+			name:  "macOS without Projects marker",
+			input: "-Users-jesperpedersen-some-folder",
+			want:  "some/folder",
+		},
+		{
+			name:  "Linux home path",
+			input: "-home-user-repos-myproject",
+			want:  "home/user/repos/myproject",
+		},
+		{
+			name:  "Linux with Projects marker",
+			input: "-home-user-Projects-org-myapp",
+			want:  "org/myapp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decodeProjectName(tt.input)
+			if got != tt.want {
+				t.Errorf("decodeProjectName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractProjectName(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "macOS with Projects",
+			path: "/Users/username/Projects/org/project",
+			want: "org/project",
+		},
+		{
+			name: "Linux home path",
+			path: "/home/user/repos/myproject",
+			want: "repos/myproject",
+		},
+		{
+			name: "Linux with Projects",
+			path: "/home/user/Projects/work/myapp",
+			want: "work/myapp",
+		},
+		{
+			name: "two components",
+			path: "/repos/myproject",
+			want: "repos/myproject",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractProjectName(tt.path)
+			if got != tt.want {
+				t.Errorf("extractProjectName(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEncodeProjectPath(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -267,18 +267,20 @@ func formatElapsed(d time.Duration) string {
 	return fmt.Sprintf("%dd ago", int(d.Hours()/24))
 }
 
-// truncate truncates a string to a maximum length
+// truncate truncates a string to a maximum visible length (in runes, not bytes).
+// This ensures multi-byte UTF-8 characters are not split mid-character.
 func truncate(s string, max int) string {
 	if max <= 0 {
 		return ""
 	}
-	if len(s) <= max {
+	runes := []rune(s)
+	if len(runes) <= max {
 		return s
 	}
 	if max <= 3 {
-		return s[:max]
+		return string(runes[:max])
 	}
-	return s[:max-3] + "..."
+	return string(runes[:max-3]) + "..."
 }
 
 // contextBarWidth is the number of block characters in the progress bar
@@ -379,21 +381,25 @@ func formatProject(s session.Session, maxLen int) string {
 	// Add git branch if present (show first, most useful)
 	if s.GitBranch != "" {
 		branch := sanitizeForTerminal(s.GitBranch)
-		if len(branch) > 12 {
-			branch = branch[:12]
+		branchRunes := []rune(branch)
+		if len(branchRunes) > 12 {
+			branchRunes = branchRunes[:12]
+			branch = string(branchRunes)
 		}
 		suffixes = append(suffixes, Dim+"@"+branch+Reset)
-		suffixLens = append(suffixLens, 1+len(branch)) // @branch
+		suffixLens = append(suffixLens, 1+len(branchRunes)) // @branch (visible rune count)
 	}
 
 	// Add session title if present
 	if s.SessionTitle != "" {
 		title := sanitizeForTerminal(s.SessionTitle)
-		if len(title) > 20 {
-			title = title[:20]
+		titleRunes := []rune(title)
+		if len(titleRunes) > 20 {
+			titleRunes = titleRunes[:20]
+			title = string(titleRunes)
 		}
 		suffixes = append(suffixes, Dim+"\""+title+"\""+Reset)
-		suffixLens = append(suffixLens, 2+len(title)) // "title"
+		suffixLens = append(suffixLens, 2+len(titleRunes)) // "title" (visible rune count)
 	}
 
 	// Ghost indicator (highest priority warning)

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -386,6 +386,16 @@ func formatProject(s session.Session, maxLen int) string {
 		suffixLens = append(suffixLens, 1+len(branch)) // @branch
 	}
 
+	// Add session title if present
+	if s.SessionTitle != "" {
+		title := sanitizeForTerminal(s.SessionTitle)
+		if len(title) > 20 {
+			title = title[:20]
+		}
+		suffixes = append(suffixes, Dim+"\""+title+"\""+Reset)
+		suffixLens = append(suffixLens, 2+len(title)) // "title"
+	}
+
 	// Ghost indicator (highest priority warning)
 	if s.IsGhost {
 		suffixes = append(suffixes, Red+"[ghost]"+Reset)

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -96,7 +96,7 @@ func handleHistory(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// Enrich with stats from the JSONL file
-			msgCount, start, end, extractedBranch, firstPrompt, _ := session.QuickSessionStats(s.LogFile)
+			msgCount, start, end, extractedBranch, firstPrompt, _, _ := session.QuickSessionStats(s.LogFile)
 			if start.IsZero() {
 				start = s.LastActivity
 			}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -96,7 +96,7 @@ func handleHistory(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// Enrich with stats from the JSONL file
-			msgCount, start, end, extractedBranch, firstPrompt := session.QuickSessionStats(s.LogFile)
+			msgCount, start, end, extractedBranch, firstPrompt, _ := session.QuickSessionStats(s.LogFile)
 			if start.IsZero() {
 				start = s.LastActivity
 			}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"runtime"
 	"time"
 )
 
@@ -62,7 +63,11 @@ func (s *Server) Start(ctx context.Context) (<-chan error, error) {
 	// Bind listener synchronously so caller knows if port is available
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to listen on port %d: %w\nUse --port <number> to specify a different port, or check what's using it: lsof -i :%d", s.port, err, s.port)
+		hint := fmt.Sprintf("lsof -i :%d", s.port)
+		if runtime.GOOS == "linux" {
+			hint = fmt.Sprintf("ss -tlnp | grep :%d", s.port)
+		}
+		return nil, fmt.Errorf("failed to listen on port %d: %w\nUse --port <number> to specify a different port, or check what's using it: %s", s.port, err, hint)
 	}
 
 	errCh := make(chan error, 1)

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -184,6 +184,7 @@
                     <span class="session-project">${esc(s.project)}</span>
                     ${stoppedBadge}
                     ${s.git_branch ? `<span class="session-branch">${esc(s.git_branch)}</span>` : ''}
+                    ${s.session_title ? `<span class="session-title">${esc(s.session_title)}</span>` : ''}
                     <span class="session-context">
                         <span class="context-bar"><span class="context-fill ${ctxCls}" style="width:${Math.min(pct, 100)}%"></span></span>
                         <span>${pct > 0 ? Math.round(pct) + '%' : '-'}</span>

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -390,6 +390,20 @@ main {
 
 .session-branch::before { content: '@'; }
 
+.session-title {
+    color: var(--muted);
+    font-size: 0.75rem;
+    font-style: italic;
+    flex-shrink: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 200px;
+}
+
+.session-title::before { content: '"'; }
+.session-title::after { content: '"'; }
+
 .session-context {
     flex-shrink: 0;
     display: flex;

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -398,7 +398,6 @@ main {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 200px;
 }
 
 .session-title::before { content: '"'; }


### PR DESCRIPTION
## Summary

- Linux process detection now uses `/proc/<pid>/cwd` instead of `lsof` (which isn't installed by default on most Linux distros)
- Project naming uses the `cwd` field from JSONL logs for accurate, lossless names on all platforms — replaces the heuristic decoding of encoded directory names that broke on Linux paths (`/home/user/...`)
- Session titles set by Claude Code (`custom-title` JSONL entries) are now displayed in both TUI and web dashboard
- Platform-aware port conflict error message (`ss -tlnp` on Linux, `lsof` on macOS)
- Linux manual install instructions added to README

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `GOOS=linux go build -o /dev/null ./...` — cross-compiles cleanly
- [x] Manual test on macOS: verify project names still display correctly
- [x] Manual test: verify session titles appear in TUI and web dashboard for sessions that have custom titles

Related: #36 (future .deb/.rpm packaging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)