### PR TITLE
fix: prevent false Working status after turn completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Sessions no longer show false "Working" status after a turn completes — turn-completed detection (`turn_duration` and `stop_reason: "end_turn"`) now takes priority over file modification time and progress heartbeat checks
 - Session title and cwd now extracted via full-file scan (`QuickSessionStats`) for both active and history views, ensuring consistency and finding titles set early in long sessions
 - Project names on Linux `/home/<user>/` paths now skip the home prefix for cleaner display (e.g., `repos/myproject` instead of `home/user/repos/myproject`)
 - UTF-8 safe truncation in TUI — branch names, session titles, and project names with multi-byte characters are no longer split mid-character

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -925,6 +925,30 @@ func determineStatus(entries []LogEntry, isRunning bool, fileModTime time.Time) 
 		return StatusNeedsInput, "Using: " + pendingToolName, false
 	}
 
+	// Check if turn completed (system message with turn_duration).
+	// This MUST come before file mod time and progress checks, because the
+	// turn_duration write itself updates the file mod time, which would
+	// otherwise cause a false "Working" status on a completed turn.
+	if lastSystem != nil {
+		if lastAssistant == nil || lastSystem.Timestamp.After(lastAssistant.Timestamp) {
+			// If a new user message arrived after the turn completed, Claude is working on it
+			if lastUser != nil && lastUser.Timestamp.After(lastSystem.Timestamp) {
+				return StatusWorking, "Processing...", false
+			}
+			return StatusWaiting, "-", false
+		}
+	}
+
+	// If the last assistant message has stop_reason "end_turn", the turn is
+	// complete even if no turn_duration system entry has been written yet.
+	if lastAssistant != nil && lastAssistant.Message != nil &&
+		lastAssistant.Message.StopReason == "end_turn" {
+		// Only if no newer user message (which would mean a new turn started)
+		if lastUser == nil || !lastUser.Timestamp.After(lastAssistant.Timestamp) {
+			return StatusWaiting, "-", false
+		}
+	}
+
 	// Progress heartbeats (progress, hook_progress, agent_progress) indicate
 	// active work: tool execution, hook callbacks, or subagent activity.
 	// A recent heartbeat is a strong signal that the session is working.
@@ -945,17 +969,6 @@ func determineStatus(entries []LogEntry, isRunning bool, fileModTime time.Time) 
 	// Ghost detection is only for --kill-ghosts to find truly orphaned processes
 	if time.Since(lastTimestamp) > 5*time.Minute {
 		return StatusWaiting, "-", false
-	}
-
-	// Check if turn completed (system message with turn_duration)
-	if lastSystem != nil {
-		if lastAssistant == nil || lastSystem.Timestamp.After(lastAssistant.Timestamp) {
-			// If a new user message arrived after the turn completed, Claude is working on it
-			if lastUser != nil && lastUser.Timestamp.After(lastSystem.Timestamp) {
-				return StatusWorking, "Processing...", false
-			}
-			return StatusWaiting, "-", false
-		}
 	}
 
 	// If assistant is recent, it's working. Use 2-minute window to avoid

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -726,6 +726,51 @@ func TestDetermineStatus(t *testing.T) {
 			wantTask:   "Processing...",
 		},
 		{
+			name: "turn completed with recent file modtime shows Waiting not Working",
+			entries: []LogEntry{
+				{Type: "assistant", Timestamp: ago(5 * time.Second), Message: &Message{
+					Content: []ContentItem{{Type: "tool_use", Name: "Bash"}},
+				}},
+				{Type: "user", Timestamp: ago(3 * time.Second), Message: &Message{
+					Content: []ContentItem{{Type: "tool_result"}},
+				}},
+				{Type: "system", Subtype: "turn_duration", Timestamp: ago(2 * time.Second)},
+			},
+			isRunning:   true,
+			fileModTime: ago(2 * time.Second),
+			wantStatus:  StatusWaiting,
+			wantTask:    "-",
+		},
+		{
+			name: "stop_reason end_turn shows Waiting",
+			entries: []LogEntry{
+				{Type: "assistant", Timestamp: ago(10 * time.Second), Message: &Message{
+					Content:    []ContentItem{{Type: "text", Text: "Done with that"}},
+					StopReason: "end_turn",
+				}},
+			},
+			isRunning:   true,
+			fileModTime: ago(5 * time.Second),
+			wantStatus:  StatusWaiting,
+			wantTask:    "-",
+		},
+		{
+			name: "stop_reason end_turn but new user message means Working",
+			entries: []LogEntry{
+				{Type: "assistant", Timestamp: ago(10 * time.Second), Message: &Message{
+					Content:    []ContentItem{{Type: "text", Text: "Done"}},
+					StopReason: "end_turn",
+				}},
+				{Type: "user", Timestamp: ago(5 * time.Second), Message: &Message{
+					Content: []ContentItem{{Type: "text", Text: "Do more"}},
+				}},
+			},
+			isRunning:   true,
+			fileModTime: ago(3 * time.Second),
+			wantStatus:  StatusWorking,
+			wantTask:    "Done",
+		},
+		{
 			name: "recent file modtime overrides stale entries",
 			entries: []LogEntry{
 				{Type: "assistant", Timestamp: ago(6 * time.Minute), Message: &Message{


### PR DESCRIPTION
## Summary
- Move turn-completed detection (`turn_duration` and `stop_reason: "end_turn"`) before file modification time and progress heartbeat checks in `determineStatus()`
- Previously, the log file mod time update from writing `turn_duration` triggered the 30-second recency check, causing a completed turn to incorrectly show as "Working"
- Add `stop_reason: "end_turn"` as an additional signal that a turn is complete

## Test plan
- [x] All existing `TestDetermineStatus` tests pass (22 cases)
- [x] New test: turn completed with recent file modtime shows Waiting not Working
- [x] New test: `stop_reason` end_turn shows Waiting
- [x] New test: `stop_reason` end_turn with new user message correctly shows Working
- [x] Full test suite passes (`go test ./...`)
- [ ] Manual: run `csm` and verify a session that just finished a turn shows "Waiting" not "Working"

🤖 Generated with [Claude Code](https://claude.com/claude-code)