### PR TITLE
feat: show session origin (terminal, Claude Desktop, or IDE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Origin column showing where each session was launched from — terminal emulator (Ghostty, iTerm, Terminal.app, WezTerm, Kitty, Alacritty, Konsole, GNOME Terminal, ...), Claude Desktop, or IDE (Zed, VS Code, Cursor, VSCodium, JetBrains). Detection walks the Claude process's parent chain and inspects its environment; results are snapshotted to `~/.claude-monitor/origins/<sessionId>.json` so the badge persists after the session ends. The column is shown in both the terminal dashboard (drops out gracefully below 90 columns) and the web dashboard, and is also included in the JSON/SSE API responses.
 - Linux process detection via `/proc/<pid>/cwd` — live session status now works correctly on Linux without requiring `lsof`
 - Project naming from `cwd` field in JSONL logs — accurate, lossless project names on all platforms (replaces heuristic decoding of encoded directory names)
 - Session title display — custom titles set by Claude Code are shown in both TUI and web dashboard

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ A lightweight CLI tool to monitor your Claude Code sessions across multiple proj
 - **Git branch display** shows current branch for each session
 - **Status indicators**: Working, Needs Input, Waiting
 - **Usage view** with API quota bars and per-session token breakdown (press `u`)
-- **Session badges**: Desktop [D], Unsandboxed [!S], Ghost [ghost]
+- **Origin column** showing whether each session was launched from a terminal (Ghostty, iTerm, Terminal.app, WezTerm, Kitty, Alacritty, Konsole, GNOME Terminal, ...), Claude Desktop, or an IDE (Zed, VS Code, Cursor, VSCodium, JetBrains); detected from the Claude process's parent chain + environment and cached to `~/.claude-monitor/origins/` so the badge survives session end
+- **Session badges**: Unsandboxed [!S], Ghost [ghost]
 - **Zero dependencies** - single binary, easy to install
 - **Cross-platform** - macOS and Linux
 - **macOS menu bar app** - native SwiftUI app for persistent session visibility
@@ -190,10 +191,13 @@ Claude Code Sessions
 
 ● Working: 1  ▲ Needs Input: 1  ◉ Waiting: 0
 
-STATUS          PROJECT                             LAST ACTIVITY   LAST MESSAGE
-───────────────────────────────────────────────────────────────────────────────────────────
-● Working       myorg/api-server @main              5s ago          Implementing auth middleware
-▲ Needs Input   work/claude-sessions-monitor @feat  12s ago         Let me check the git status
+STATUS          PROJECT                             ORIGIN     CONTEXT          LAST ACTIVITY
+─────────────────────────────────────────────────────────────────────────────────────────────
+● Working       myorg/api-server @main              Ghostty    ███████░░░ 68%   Now
+  Implementing auth middleware
+
+▲ Needs Input   work/claude-sessions-monitor @feat  Zed        ██░░░░░░░░ 21%   12s ago
+  Let me check the git status
 
 h: history | u: usage | Ctrl+C: quit
 ```

--- a/internal/session/origin.go
+++ b/internal/session/origin.go
@@ -107,10 +107,8 @@ func classifyOrigin(env map[string]string, ancestors []ProcessInfo) Origin {
 	if tp := env["TERM_PROGRAM"]; tp == "zed" {
 		return newOrigin("zed")
 	}
-	if _, ok := env["TERMINAL_EMULATOR"]; ok {
-		if env["TERMINAL_EMULATOR"] == "JetBrains-JediTerm" {
-			return newOrigin("jetbrains")
-		}
+	if env["TERMINAL_EMULATOR"] == "JetBrains-JediTerm" {
+		return newOrigin("jetbrains")
 	}
 
 	// The first ancestor is usually the claude CLI process itself; what we

--- a/internal/session/origin.go
+++ b/internal/session/origin.go
@@ -1,0 +1,265 @@
+package session
+
+import "strings"
+
+// OriginCategory is a high-level grouping of where a Claude Code session was launched from.
+type OriginCategory string
+
+const (
+	OriginUnknown  OriginCategory = ""
+	OriginTerminal OriginCategory = "terminal"
+	OriginDesktop  OriginCategory = "desktop"
+	OriginIDE      OriginCategory = "ide"
+)
+
+// Origin describes the environment that spawned a Claude session.
+type Origin struct {
+	Category OriginCategory `json:"category,omitempty"`
+	App      string         `json:"app,omitempty"`     // stable slug: "ghostty", "iterm", "zed", "vscode", "cursor", ...
+	Display  string         `json:"display,omitempty"` // pretty name for UI: "Ghostty", "VS Code", ...
+}
+
+// IsZero reports whether no origin information is set.
+func (o Origin) IsZero() bool {
+	return o.Category == OriginUnknown && o.App == "" && o.Display == ""
+}
+
+// appCatalog maps the stable app slug to its pretty display name and category.
+// Order matters only for documentation; lookup is by slug.
+var appCatalog = map[string]struct {
+	Display  string
+	Category OriginCategory
+}{
+	// Terminals
+	"ghostty":        {"Ghostty", OriginTerminal},
+	"iterm":          {"iTerm", OriginTerminal},
+	"terminal":       {"Terminal", OriginTerminal}, // macOS Terminal.app
+	"apple-terminal": {"Terminal", OriginTerminal},
+	"wezterm":        {"WezTerm", OriginTerminal},
+	"kitty":          {"Kitty", OriginTerminal},
+	"alacritty":      {"Alacritty", OriginTerminal},
+	"konsole":        {"Konsole", OriginTerminal},
+	"gnome-terminal": {"GNOME Terminal", OriginTerminal},
+	"xterm":          {"xterm", OriginTerminal},
+	"terminator":     {"Terminator", OriginTerminal},
+	"tmux":           {"tmux", OriginTerminal}, // best-effort when we can't see further up
+	// IDEs
+	"zed":      {"Zed", OriginIDE},
+	"vscode":   {"VS Code", OriginIDE},
+	"codium":   {"VSCodium", OriginIDE},
+	"cursor":   {"Cursor", OriginIDE},
+	"jetbrains": {"JetBrains", OriginIDE},
+	// Desktop
+	"claude-desktop": {"Claude Desktop", OriginDesktop},
+}
+
+// newOrigin looks up the catalog entry for a slug and returns a populated Origin.
+// Falls back to Unknown if the slug is not registered.
+func newOrigin(app string) Origin {
+	if entry, ok := appCatalog[app]; ok {
+		return Origin{Category: entry.Category, App: app, Display: entry.Display}
+	}
+	return Origin{}
+}
+
+// ProcessInfo describes one process in the ancestor chain.
+// On Darwin, Exe holds whatever `ps -o comm=` returned (often the full
+// "/Applications/Ghostty.app/Contents/MacOS/ghostty" path). On Linux it's
+// the resolved /proc/<pid>/exe target, falling back to /proc/<pid>/comm
+// when exe is not readable.
+type ProcessInfo struct {
+	PID  int
+	Comm string // short command name (max 15 chars on Linux)
+	Exe  string // full path if available
+}
+
+// classifyOrigin is a pure function that maps the detection signals (env
+// variables and ancestor process chain) to an Origin. It must not touch the
+// filesystem or spawn subprocesses so it can be unit-tested with synthetic
+// input.
+//
+// Precedence (highest wins):
+//  1. IDE env vars (Zed, VS Code, Cursor, JetBrains)
+//  2. IDE ancestor bundle/exe match
+//  3. Claude Desktop (bundle id or Claude.app ancestor)
+//  4. Terminal env vars (TERM_PROGRAM and friends)
+//  5. Terminal ancestor exe match
+//  6. Unknown
+func classifyOrigin(env map[string]string, ancestors []ProcessInfo) Origin {
+	// 1. IDE env vars — checked first because an IDE-hosted terminal also
+	// sets TERM_PROGRAM (sometimes to the IDE itself, sometimes to the host
+	// terminal), so we look for IDE-specific markers explicitly.
+	if _, ok := env["CURSOR_TRACE_ID"]; ok {
+		return newOrigin("cursor")
+	}
+	if _, ok := env["VSCODE_INJECTION"]; ok {
+		return vscodeVariant(env)
+	}
+	if _, ok := env["VSCODE_PID"]; ok {
+		return vscodeVariant(env)
+	}
+	if tp := env["TERM_PROGRAM"]; tp == "vscode" {
+		return vscodeVariant(env)
+	}
+	if _, ok := env["ZED_TERM"]; ok {
+		return newOrigin("zed")
+	}
+	if tp := env["TERM_PROGRAM"]; tp == "zed" {
+		return newOrigin("zed")
+	}
+	if _, ok := env["TERMINAL_EMULATOR"]; ok {
+		if env["TERMINAL_EMULATOR"] == "JetBrains-JediTerm" {
+			return newOrigin("jetbrains")
+		}
+	}
+
+	// The first ancestor is usually the claude CLI process itself; what we
+	// want is whatever spawned it, so skip index 0 for all ancestor scans.
+	parents := ancestors
+	if len(parents) > 0 {
+		parents = parents[1:]
+	}
+
+	// 2. IDE ancestor match.
+	for _, p := range parents {
+		switch {
+		case ancestorMatches(p, "Cursor"):
+			return newOrigin("cursor")
+		case ancestorMatches(p, "Zed"):
+			return newOrigin("zed")
+		case ancestorMatches(p, "Visual Studio Code", "Code", "Code - Insiders"):
+			return newOrigin("vscode")
+		case ancestorMatches(p, "VSCodium", "codium"):
+			return newOrigin("codium")
+		case ancestorMatches(p, "IntelliJ IDEA", "PyCharm", "WebStorm", "GoLand", "RubyMine", "PhpStorm", "CLion", "DataGrip", "Rider", "Android Studio"):
+			return newOrigin("jetbrains")
+		}
+	}
+
+	// 3. Terminal env vars. Checked before Claude Desktop because a real
+	// terminal emulator always stamps TERM_PROGRAM / its own marker vars,
+	// whereas Claude Desktop-spawned processes don't.
+	if tp := env["TERM_PROGRAM"]; tp != "" {
+		switch strings.ToLower(tp) {
+		case "ghostty":
+			return newOrigin("ghostty")
+		case "iterm.app":
+			return newOrigin("iterm")
+		case "apple_terminal":
+			return newOrigin("apple-terminal")
+		case "wezterm":
+			return newOrigin("wezterm")
+		}
+	}
+	if _, ok := env["KITTY_WINDOW_ID"]; ok {
+		return newOrigin("kitty")
+	}
+	if _, ok := env["ALACRITTY_WINDOW_ID"]; ok {
+		return newOrigin("alacritty")
+	}
+	if _, ok := env["KONSOLE_VERSION"]; ok {
+		return newOrigin("konsole")
+	}
+	if _, ok := env["WEZTERM_EXECUTABLE"]; ok {
+		return newOrigin("wezterm")
+	}
+	if _, ok := env["GHOSTTY_RESOURCES_DIR"]; ok {
+		return newOrigin("ghostty")
+	}
+
+	// 4. Terminal ancestor exe match.
+	for _, p := range parents {
+		switch {
+		case ancestorMatches(p, "Ghostty"):
+			return newOrigin("ghostty")
+		case ancestorMatches(p, "iTerm", "iTerm2"):
+			return newOrigin("iterm")
+		case ancestorMatches(p, "Terminal"):
+			return newOrigin("apple-terminal")
+		case ancestorMatches(p, "WezTerm"):
+			return newOrigin("wezterm")
+		case ancestorMatches(p, "Alacritty", "alacritty"):
+			return newOrigin("alacritty")
+		case ancestorMatches(p, "kitty"):
+			return newOrigin("kitty")
+		case ancestorMatches(p, "konsole"):
+			return newOrigin("konsole")
+		case ancestorMatches(p, "gnome-terminal-server", "gnome-terminal"):
+			return newOrigin("gnome-terminal")
+		case ancestorMatches(p, "terminator"):
+			return newOrigin("terminator")
+		case ancestorMatches(p, "xterm"):
+			return newOrigin("xterm")
+		}
+	}
+
+	// 5. Claude Desktop — only if a proper Claude.app bundle shows up in
+	// the ancestor chain, or the bundle id is explicitly set. A bare exe
+	// named "claude" is the Claude CLI, not Claude Desktop.
+	if env["__CFBundleIdentifier"] == "com.anthropic.claude" {
+		return newOrigin("claude-desktop")
+	}
+	for _, p := range parents {
+		if claudeDesktopAncestor(p) {
+			return newOrigin("claude-desktop")
+		}
+	}
+
+	return Origin{}
+}
+
+// claudeDesktopAncestor reports whether the ancestor looks like the
+// "Claude Desktop" macOS app bundle (not the `claude` CLI exe).
+func claudeDesktopAncestor(p ProcessInfo) bool {
+	commLC := strings.ToLower(p.Comm)
+	exeLC := strings.ToLower(p.Exe)
+	return strings.Contains(commLC, "/claude.app/") || strings.Contains(exeLC, "/claude.app/")
+}
+
+// vscodeVariant distinguishes Cursor from vanilla VS Code when only VSCODE_*
+// markers are present (Cursor sets them too).
+func vscodeVariant(env map[string]string) Origin {
+	if _, ok := env["CURSOR_TRACE_ID"]; ok {
+		return newOrigin("cursor")
+	}
+	return newOrigin("vscode")
+}
+
+// DetectOrigin classifies the Claude process identified by pid.
+// Returns a zero-valued Origin on any failure (the caller should treat that
+// as "unknown" and neither display nor persist it).
+func DetectOrigin(pid int) Origin {
+	if pid <= 0 {
+		return Origin{}
+	}
+	env := readProcessEnv(pid)
+	chain := parentChain(pid)
+	return classifyOrigin(env, chain)
+}
+
+// ancestorMatches reports whether the process's comm or exe path contains any
+// of the given needle tokens (case-insensitive substring match). App bundle
+// names like "Ghostty" match "/Applications/Ghostty.app/Contents/MacOS/ghostty".
+func ancestorMatches(p ProcessInfo, needles ...string) bool {
+	commLC := strings.ToLower(p.Comm)
+	exeLC := strings.ToLower(p.Exe)
+	for _, n := range needles {
+		nLC := strings.ToLower(n)
+		// Match bundle paths like ".../Ghostty.app/..." or bare exe like "ghostty".
+		if strings.Contains(exeLC, "/"+nLC+".app/") {
+			return true
+		}
+		if commLC == nLC || exeLC == nLC {
+			return true
+		}
+		// /usr/bin/ghostty, /opt/zed/zed, etc.
+		if strings.HasSuffix(exeLC, "/"+nLC) {
+			return true
+		}
+		// macOS comm often already contains the full bundle path from `ps -o comm=`
+		if strings.Contains(commLC, "/"+nLC+".app/") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/session/origin_detect_darwin.go
+++ b/internal/session/origin_detect_darwin.go
@@ -1,0 +1,89 @@
+//go:build darwin
+
+package session
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// readProcessEnv returns the environment of a running process on macOS.
+// Uses `ps -E -ww -p <pid> -o command=` to get KEY=VALUE tokens; `-ww`
+// disables truncation of the output line.
+func readProcessEnv(pid int) map[string]string {
+	env := make(map[string]string)
+	out, err := exec.Command("ps", "-E", "-ww", "-p", fmt.Sprintf("%d", pid), "-o", "command=").Output()
+	if err != nil {
+		return env
+	}
+
+	// The first token is the command path; everything after is KEY=VALUE
+	// separated by spaces. Values containing spaces would break this, but
+	// process env values almost never do in practice.
+	for _, tok := range strings.Fields(string(out)) {
+		eq := strings.IndexByte(tok, '=')
+		if eq <= 0 {
+			continue
+		}
+		key := tok[:eq]
+		// Key must look like a shell identifier.
+		if !isEnvKey(key) {
+			continue
+		}
+		env[key] = tok[eq+1:]
+	}
+	return env
+}
+
+// parentChain walks ancestors starting from pid upward until pid 1 or 10 hops.
+// Each step uses `ps -p <pid> -o ppid=,comm=`; on macOS `comm` for GUI-launched
+// apps typically returns the full executable path inside the bundle.
+func parentChain(pid int) []ProcessInfo {
+	var chain []ProcessInfo
+	current := pid
+	for hops := 0; hops < 10 && current > 1; hops++ {
+		out, err := exec.Command("ps", "-p", fmt.Sprintf("%d", current), "-o", "ppid=,comm=").Output()
+		if err != nil {
+			return chain
+		}
+		line := strings.TrimSpace(string(out))
+		if line == "" {
+			return chain
+		}
+		// ppid then comm; comm may contain spaces so split on first field only.
+		fields := strings.SplitN(line, " ", 2)
+		if len(fields) < 2 {
+			return chain
+		}
+		var ppid int
+		if _, err := fmt.Sscanf(fields[0], "%d", &ppid); err != nil {
+			return chain
+		}
+		comm := strings.TrimSpace(fields[1])
+		chain = append(chain, ProcessInfo{PID: current, Comm: comm, Exe: comm})
+		if ppid <= 1 {
+			return chain
+		}
+		current = ppid
+	}
+	return chain
+}
+
+// isEnvKey reports whether s looks like a POSIX env var name.
+func isEnvKey(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		isAlpha := (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == '_'
+		isDigit := r >= '0' && r <= '9'
+		if i == 0 && !isAlpha {
+			return false
+		}
+		if !isAlpha && !isDigit {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/session/origin_detect_linux.go
+++ b/internal/session/origin_detect_linux.go
@@ -1,0 +1,86 @@
+//go:build linux
+
+package session
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// readProcessEnv returns the environment of a running process on Linux via
+// /proc/<pid>/environ. Only readable when csm runs as the same UID as the
+// target process; returns an empty map on permission errors.
+func readProcessEnv(pid int) map[string]string {
+	env := make(map[string]string)
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+	if err != nil {
+		return env
+	}
+	for _, entry := range bytes.Split(data, []byte{0}) {
+		if len(entry) == 0 {
+			continue
+		}
+		eq := bytes.IndexByte(entry, '=')
+		if eq <= 0 {
+			continue
+		}
+		env[string(entry[:eq])] = string(entry[eq+1:])
+	}
+	return env
+}
+
+// parentChain walks ancestors using /proc/<pid>/status for ppid and
+// /proc/<pid>/exe for the executable path (falling back to /proc/<pid>/comm
+// when exe is not readable).
+func parentChain(pid int) []ProcessInfo {
+	var chain []ProcessInfo
+	current := pid
+	for hops := 0; hops < 10 && current > 1; hops++ {
+		ppid, ok := readPPid(current)
+		if !ok {
+			return chain
+		}
+		comm := readComm(current)
+		exe := readExe(current)
+		chain = append(chain, ProcessInfo{PID: current, Comm: comm, Exe: exe})
+		if ppid <= 1 {
+			return chain
+		}
+		current = ppid
+	}
+	return chain
+}
+
+func readPPid(pid int) (int, bool) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		return 0, false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "PPid:") {
+			var ppid int
+			if _, err := fmt.Sscanf(line, "PPid:\t%d", &ppid); err == nil {
+				return ppid, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func readComm(pid int) string {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func readExe(pid int) string {
+	exe, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
+	if err != nil {
+		return ""
+	}
+	return exe
+}

--- a/internal/session/origin_store.go
+++ b/internal/session/origin_store.go
@@ -1,0 +1,82 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// originStoreDirFn is overridable in tests.
+var originStoreDirFn = defaultOriginStoreDir
+
+func defaultOriginStoreDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".claude-monitor", "origins"), nil
+}
+
+// OriginStoreDir returns the directory where per-session origin snapshots are persisted.
+func OriginStoreDir() (string, error) {
+	return originStoreDirFn()
+}
+
+// LoadOrigin reads the cached origin for the given session UUID.
+// Returns (Origin{}, false) when no cache exists or on any read/parse error.
+func LoadOrigin(sessionID string) (Origin, bool) {
+	if sessionID == "" {
+		return Origin{}, false
+	}
+	dir, err := OriginStoreDir()
+	if err != nil {
+		return Origin{}, false
+	}
+	data, err := os.ReadFile(filepath.Join(dir, sessionID+".json"))
+	if err != nil {
+		return Origin{}, false
+	}
+	var o Origin
+	if err := json.Unmarshal(data, &o); err != nil {
+		return Origin{}, false
+	}
+	if o.IsZero() {
+		return Origin{}, false
+	}
+	return o, true
+}
+
+// SaveOrigin persists a detected origin for a session. Empty sessionIDs and
+// zero-valued origins are skipped (nothing useful to cache).
+func SaveOrigin(sessionID string, o Origin) error {
+	if sessionID == "" || o.IsZero() {
+		return nil
+	}
+	dir, err := OriginStoreDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create origin store dir: %w", err)
+	}
+	data, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	target := filepath.Join(dir, sessionID+".json")
+	tmp, err := os.CreateTemp(dir, sessionID+".*.json.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op if rename succeeded
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, target)
+}

--- a/internal/session/origin_store_test.go
+++ b/internal/session/origin_store_test.go
@@ -1,0 +1,61 @@
+package session
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestOriginStoreRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	originStoreDirFn = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { originStoreDirFn = defaultOriginStoreDir })
+
+	sid := "d3adbeef-0000-1111-2222-aaaabbbbcccc"
+	want := Origin{Category: OriginTerminal, App: "ghostty", Display: "Ghostty"}
+
+	if err := SaveOrigin(sid, want); err != nil {
+		t.Fatalf("SaveOrigin: %v", err)
+	}
+
+	got, ok := LoadOrigin(sid)
+	if !ok {
+		t.Fatalf("LoadOrigin returned ok=false after save")
+	}
+	if got != want {
+		t.Errorf("LoadOrigin = %+v, want %+v", got, want)
+	}
+
+	// File must exist at the expected path.
+	if _, err := filepath.Abs(filepath.Join(dir, sid+".json")); err != nil {
+		t.Fatalf("expected file path unreachable: %v", err)
+	}
+}
+
+func TestOriginStoreSkipsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	originStoreDirFn = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { originStoreDirFn = defaultOriginStoreDir })
+
+	// Zero origin should be a no-op.
+	if err := SaveOrigin("sid", Origin{}); err != nil {
+		t.Fatalf("SaveOrigin with zero origin: %v", err)
+	}
+	if _, ok := LoadOrigin("sid"); ok {
+		t.Fatalf("LoadOrigin should return ok=false for never-saved id")
+	}
+
+	// Empty session id should be a no-op.
+	if err := SaveOrigin("", Origin{Category: OriginTerminal, App: "ghostty", Display: "Ghostty"}); err != nil {
+		t.Fatalf("SaveOrigin with empty sid: %v", err)
+	}
+}
+
+func TestLoadOriginMissing(t *testing.T) {
+	dir := t.TempDir()
+	originStoreDirFn = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { originStoreDirFn = defaultOriginStoreDir })
+
+	if _, ok := LoadOrigin("no-such-id"); ok {
+		t.Errorf("LoadOrigin of missing id should return ok=false")
+	}
+}

--- a/internal/session/origin_test.go
+++ b/internal/session/origin_test.go
@@ -1,0 +1,200 @@
+package session
+
+import "testing"
+
+func TestClassifyOrigin(t *testing.T) {
+	tests := []struct {
+		name      string
+		env       map[string]string
+		ancestors []ProcessInfo
+		want      Origin
+	}{
+		{
+			name: "ghostty via TERM_PROGRAM",
+			env: map[string]string{
+				"TERM_PROGRAM":          "ghostty",
+				"GHOSTTY_RESOURCES_DIR": "/Applications/Ghostty.app/Contents/Resources/ghostty",
+				"__CFBundleIdentifier":  "com.mitchellh.ghostty",
+			},
+			ancestors: []ProcessInfo{
+				{PID: 99, Comm: "-/bin/zsh"},
+				{PID: 42, Comm: "/Applications/Ghostty.app/Contents/MacOS/ghostty"},
+			},
+			want: Origin{Category: OriginTerminal, App: "ghostty", Display: "Ghostty"},
+		},
+		{
+			name: "iterm via TERM_PROGRAM",
+			env: map[string]string{
+				"TERM_PROGRAM": "iTerm.app",
+				"LC_TERMINAL":  "iTerm2",
+			},
+			want: Origin{Category: OriginTerminal, App: "iterm", Display: "iTerm"},
+		},
+		{
+			name: "apple terminal via TERM_PROGRAM",
+			env: map[string]string{
+				"TERM_PROGRAM": "Apple_Terminal",
+			},
+			want: Origin{Category: OriginTerminal, App: "apple-terminal", Display: "Terminal"},
+		},
+		{
+			name: "terminal ancestor fallback when no env",
+			env:  map[string]string{},
+			ancestors: []ProcessInfo{
+				{PID: 1001, Comm: "claude"}, // skipped
+				{PID: 99, Comm: "zsh"},
+				{PID: 42, Exe: "/Applications/Ghostty.app/Contents/MacOS/ghostty"},
+			},
+			want: Origin{Category: OriginTerminal, App: "ghostty", Display: "Ghostty"},
+		},
+		{
+			// Regression for live macOS Ghostty+Claude chain where the bare
+			// "claude" comm was previously misclassifying as Claude Desktop.
+			name: "ghostty wins over bare claude CLI in chain",
+			env: map[string]string{
+				"TERM_PROGRAM":         "ghostty",
+				"__CFBundleIdentifier": "com.mitchellh.ghostty",
+			},
+			ancestors: []ProcessInfo{
+				{PID: 9034, Comm: "claude", Exe: "claude"},
+				{PID: 53621, Comm: "-/bin/zsh", Exe: "-/bin/zsh"},
+				{PID: 53620, Comm: "/usr/bin/login", Exe: "/usr/bin/login"},
+				{PID: 1213, Comm: "/Applications/Ghostty.app/Contents/MacOS/ghostty", Exe: "/Applications/Ghostty.app/Contents/MacOS/ghostty"},
+			},
+			want: Origin{Category: OriginTerminal, App: "ghostty", Display: "Ghostty"},
+		},
+		{
+			name: "zed via ZED_TERM",
+			env: map[string]string{
+				"ZED_TERM":     "true",
+				"TERM_PROGRAM": "zed",
+			},
+			want: Origin{Category: OriginIDE, App: "zed", Display: "Zed"},
+		},
+		{
+			name: "zed via ancestor on linux",
+			env:  map[string]string{},
+			ancestors: []ProcessInfo{
+				{PID: 1001, Comm: "claude"},
+				{PID: 99, Comm: "zsh"},
+				{PID: 42, Exe: "/opt/zed/zed"},
+			},
+			want: Origin{Category: OriginIDE, App: "zed", Display: "Zed"},
+		},
+		{
+			name: "vscode via VSCODE_INJECTION",
+			env: map[string]string{
+				"VSCODE_INJECTION": "1",
+				"TERM_PROGRAM":     "vscode",
+			},
+			want: Origin{Category: OriginIDE, App: "vscode", Display: "VS Code"},
+		},
+		{
+			name: "cursor via CURSOR_TRACE_ID overrides vscode",
+			env: map[string]string{
+				"VSCODE_INJECTION": "1",
+				"CURSOR_TRACE_ID":  "abc123",
+				"TERM_PROGRAM":     "vscode",
+			},
+			want: Origin{Category: OriginIDE, App: "cursor", Display: "Cursor"},
+		},
+		{
+			name: "claude desktop via bundle id",
+			env: map[string]string{
+				"__CFBundleIdentifier": "com.anthropic.claude",
+			},
+			want: Origin{Category: OriginDesktop, App: "claude-desktop", Display: "Claude Desktop"},
+		},
+		{
+			name: "claude desktop via ancestor",
+			env:  map[string]string{},
+			ancestors: []ProcessInfo{
+				{PID: 1001, Comm: "claude"}, // the Claude CLI itself — skipped
+				{PID: 42, Comm: "/Applications/Claude.app/Contents/MacOS/Claude"},
+			},
+			want: Origin{Category: OriginDesktop, App: "claude-desktop", Display: "Claude Desktop"},
+		},
+		{
+			name: "ide env wins over terminal ancestor",
+			env: map[string]string{
+				"TERM_PROGRAM":     "ghostty",
+				"VSCODE_INJECTION": "1",
+			},
+			ancestors: []ProcessInfo{
+				{PID: 1001, Comm: "claude"},
+				{PID: 42, Exe: "/Applications/Ghostty.app/Contents/MacOS/ghostty"},
+			},
+			want: Origin{Category: OriginIDE, App: "vscode", Display: "VS Code"},
+		},
+		{
+			name: "kitty via env",
+			env: map[string]string{
+				"KITTY_WINDOW_ID": "1",
+				"TERM":            "xterm-kitty",
+			},
+			want: Origin{Category: OriginTerminal, App: "kitty", Display: "Kitty"},
+		},
+		{
+			name: "alacritty via env",
+			env: map[string]string{
+				"ALACRITTY_WINDOW_ID": "0x1234",
+			},
+			want: Origin{Category: OriginTerminal, App: "alacritty", Display: "Alacritty"},
+		},
+		{
+			name: "wezterm via env",
+			env: map[string]string{
+				"TERM_PROGRAM":       "WezTerm",
+				"WEZTERM_EXECUTABLE": "/usr/local/bin/wezterm",
+			},
+			want: Origin{Category: OriginTerminal, App: "wezterm", Display: "WezTerm"},
+		},
+		{
+			name: "gnome terminal via ancestor",
+			env:  map[string]string{"VTE_VERSION": "7600"},
+			ancestors: []ProcessInfo{
+				{PID: 1001, Comm: "claude"}, // the Claude CLI itself — skipped
+				{PID: 42, Exe: "/usr/libexec/gnome-terminal-server"},
+			},
+			want: Origin{Category: OriginTerminal, App: "gnome-terminal", Display: "GNOME Terminal"},
+		},
+		{
+			name: "jetbrains via TERMINAL_EMULATOR",
+			env: map[string]string{
+				"TERMINAL_EMULATOR": "JetBrains-JediTerm",
+			},
+			want: Origin{Category: OriginIDE, App: "jetbrains", Display: "JetBrains"},
+		},
+		{
+			name:      "unknown when nothing matches",
+			env:       map[string]string{"TERM": "xterm-256color"},
+			ancestors: []ProcessInfo{{PID: 1, Comm: "launchd"}},
+			want:      Origin{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyOrigin(tt.env, tt.ancestors)
+			if got != tt.want {
+				t.Errorf("classifyOrigin() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOriginIsZero(t *testing.T) {
+	if !(Origin{}).IsZero() {
+		t.Errorf("zero Origin should report IsZero() == true")
+	}
+	if (Origin{Category: OriginTerminal, App: "ghostty", Display: "Ghostty"}).IsZero() {
+		t.Errorf("populated Origin should report IsZero() == false")
+	}
+}
+
+func TestNewOriginUnknownSlug(t *testing.T) {
+	o := newOrigin("no-such-app")
+	if !o.IsZero() {
+		t.Errorf("newOrigin with unknown slug should return zero Origin, got %+v", o)
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -35,11 +35,12 @@ type Session struct {
 	Summary        string    `json:"summary,omitempty"`
 	LastMessage    string    `json:"last_message,omitempty"`
 	LogFile        string    `json:"log_file"`
-	ProjectPath    string    `json:"-"`                        // Full path to the project directory
-	IsDesktop      bool      `json:"is_desktop,omitempty"`     // True if session appears to be from desktop app
-	IsGhost        bool      `json:"is_ghost,omitempty"`       // True if process running but log is stale
-	GhostPID       int       `json:"ghost_pid,omitempty"`      // PID of the ghost process (for killing)
-	GitBranch      string    `json:"git_branch,omitempty"`     // Current git branch
+	ProjectPath    string    `json:"-"`                         // Full path to the project directory
+	SessionID      string    `json:"session_id,omitempty"`      // Claude session UUID (log filename stem)
+	Origin         Origin    `json:"origin,omitempty"`          // Where the session was launched from
+	IsGhost        bool      `json:"is_ghost,omitempty"`        // True if process running but log is stale
+	GhostPID       int       `json:"ghost_pid,omitempty"`       // PID of the ghost process (for killing)
+	GitBranch      string    `json:"git_branch,omitempty"`      // Current git branch
 	HasUnsandboxed bool      `json:"has_unsandboxed,omitempty"` // True if any command bypassed sandbox
 	ContextPercent float64   `json:"context_percent,omitempty"` // Percentage of context window used
 	ContextTokens  int       `json:"context_tokens,omitempty"`  // Total input tokens from last usage entry
@@ -261,6 +262,13 @@ func getProcessCwd(pid int) (string, error) {
 	return "", fmt.Errorf("cwd not found in lsof output for pid %d", pid)
 }
 
+// sessionIDFromLogFile returns the session UUID from a log file path.
+// Claude Code names each session log "<uuid>.jsonl" so the stem is the session id.
+func sessionIDFromLogFile(logFile string) string {
+	base := filepath.Base(logFile)
+	return strings.TrimSuffix(base, ".jsonl")
+}
+
 // encodeProjectPath converts a filesystem path to the encoded directory name format
 func encodeProjectPath(path string) string {
 	// /Users/username/Projects/org/project -> -Users-username-Projects-org-project
@@ -269,17 +277,6 @@ func encodeProjectPath(path string) string {
 	encoded = strings.ReplaceAll(encoded, ".", "-")
 	encoded = strings.ReplaceAll(encoded, "_", "-")
 	return encoded
-}
-
-// isDesktopSession checks if the project path appears to be from the desktop app
-// Desktop app sessions typically have cwd at the home directory (e.g., -Users-username)
-func isDesktopSession(projectName string) bool {
-	// NOTE: Desktop detection is disabled because the previous heuristic
-	// (home directory = desktop) was unreliable - terminal sessions can also
-	// be started from the home directory.
-	// TODO: Find a more reliable detection method (e.g., check parent process)
-	_ = projectName
-	return false
 }
 
 // Discover finds all active Claude sessions
@@ -511,7 +508,7 @@ func parseSession(projectName, logFile string, pids []int) (Session, error) {
 		LogFile:     logFile,
 		Status:      StatusInactive, // Default to inactive
 		ProjectPath: projectName,    // Store the encoded name for matching
-		IsDesktop:   isDesktopSession(projectName),
+		SessionID:   sessionIDFromLogFile(logFile),
 	}
 
 	// Check if Claude is running in this project directory
@@ -519,6 +516,19 @@ func parseSession(projectName, logFile string, pids []int) (Session, error) {
 	pid := 0
 	if isRunning {
 		pid = pids[0]
+	}
+
+	// Resolve the session's origin (terminal / IDE / Claude Desktop).
+	// Historical sessions can only be classified if we previously cached them
+	// while live, so we load from cache first and only detect when the process
+	// is still running and no cache entry exists.
+	if cached, ok := LoadOrigin(session.SessionID); ok {
+		session.Origin = cached
+	} else if isRunning && pid > 0 {
+		if detected := DetectOrigin(pid); !detected.IsZero() {
+			session.Origin = detected
+			_ = SaveOrigin(session.SessionID, detected)
+		}
 	}
 
 	// Get file modification time as fallback for last activity

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -3,9 +3,11 @@ package ui
 // Column width constraints for session table
 const (
 	fixedStatusWidth   = 14 // "● Needs Input" = 13 chars + 1 padding
+	fixedOriginWidth   = 10 // "Claude Desktop" truncated; most origins fit in 9
 	fixedContextWidth  = 16 // progress bar (10) + " 100%" (5) + 1 padding
 	fixedActivityWidth = 15 // "LAST ACTIVITY" header + padding
 	minProjectWidth    = 15
+	originColumnMinTTY = 90 // drop the origin column below this terminal width
 )
 
 // sessionLayout holds the computed column widths for the session table.
@@ -13,31 +15,40 @@ const (
 type sessionLayout struct {
 	status     int
 	project    int
+	origin     int
 	context    int
 	activity   int
 	totalWidth int
 }
 
 // calcSessionLayout computes column widths for the given terminal width.
-// Fixed columns (status, context, activity) keep their size.
-// All remaining space goes to the project column.
-// Accounts for 3 separator spaces between the 4 columns.
+// Fixed columns (status, origin, context, activity) keep their size.
+// All remaining space goes to the project column. The origin column is
+// dropped on narrow terminals to keep the project column readable.
+// Accounts for one separator space between each pair of adjacent columns.
 func calcSessionLayout(width int) sessionLayout {
 	l := sessionLayout{
 		status:   fixedStatusWidth,
 		context:  fixedContextWidth,
 		activity: fixedActivityWidth,
 	}
+	if width >= originColumnMinTTY {
+		l.origin = fixedOriginWidth
+	}
 
-	const columnGaps = 3 // spaces between 4 columns
-	fixed := l.status + l.context + l.activity + columnGaps
+	// One space between each pair of adjacent visible columns.
+	gaps := 3 // status|project|context|activity
+	if l.origin > 0 {
+		gaps = 4 // status|project|origin|context|activity
+	}
+	fixed := l.status + l.origin + l.context + l.activity + gaps
 	remaining := width - fixed
 	if remaining < 1 {
 		remaining = 1
 	}
 	l.project = remaining
 
-	l.totalWidth = l.status + l.project + l.context + l.activity + columnGaps
+	l.totalWidth = l.status + l.project + l.origin + l.context + l.activity + gaps
 
 	return l
 }

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -8,14 +8,17 @@ func TestCalcSessionLayout_WideTerminal(t *testing.T) {
 	if l.status != 14 {
 		t.Errorf("expected status=14, got %d", l.status)
 	}
+	if l.origin != fixedOriginWidth {
+		t.Errorf("expected origin=%d, got %d", fixedOriginWidth, l.origin)
+	}
 	if l.context != 16 {
 		t.Errorf("expected context=16, got %d", l.context)
 	}
 	if l.activity != 15 {
 		t.Errorf("expected activity=15, got %d", l.activity)
 	}
-	// All remaining space goes to project (minus 3 column gaps)
-	expectedProject := 140 - fixedStatusWidth - fixedContextWidth - fixedActivityWidth - 3
+	// Remaining space goes to project (minus 4 column gaps since origin column is present)
+	expectedProject := 140 - fixedStatusWidth - fixedOriginWidth - fixedContextWidth - fixedActivityWidth - 4
 	if l.project != expectedProject {
 		t.Errorf("expected project=%d, got %d", expectedProject, l.project)
 	}
@@ -25,20 +28,27 @@ func TestCalcSessionLayout_WideTerminal(t *testing.T) {
 }
 
 func TestCalcSessionLayout_NarrowTerminal(t *testing.T) {
+	// 80 < originColumnMinTTY, so origin column is hidden.
 	l := calcSessionLayout(80)
 
 	if l.status != 14 {
 		t.Errorf("expected status=14, got %d", l.status)
 	}
+	if l.origin != 0 {
+		t.Errorf("expected origin=0 at width=80, got %d", l.origin)
+	}
 	if l.totalWidth != 80 {
-		t.Errorf("expected totalWidth=80, got %d (status=%d project=%d context=%d activity=%d)",
-			l.totalWidth, l.status, l.project, l.context, l.activity)
+		t.Errorf("expected totalWidth=80, got %d (status=%d project=%d origin=%d context=%d activity=%d)",
+			l.totalWidth, l.status, l.project, l.origin, l.context, l.activity)
 	}
 }
 
 func TestCalcSessionLayout_VeryNarrowTerminal(t *testing.T) {
 	l := calcSessionLayout(55)
 
+	if l.origin != 0 {
+		t.Errorf("expected origin=0 at width=55, got %d", l.origin)
+	}
 	if l.totalWidth != 55 {
 		t.Errorf("expected totalWidth=55, got %d", l.totalWidth)
 	}
@@ -47,13 +57,28 @@ func TestCalcSessionLayout_VeryNarrowTerminal(t *testing.T) {
 func TestCalcSessionLayout_MinWidth(t *testing.T) {
 	l := calcSessionLayout(40)
 
-	// At tiny widths, project uses whatever space remains (minus 3 column gaps)
+	// At tiny widths the origin column is dropped; project gets whatever remains (minus 3 gaps).
 	expected := 40 - fixedStatusWidth - fixedContextWidth - fixedActivityWidth - 3
 	if expected < 1 {
 		expected = 1
 	}
+	if l.origin != 0 {
+		t.Errorf("expected origin=0 at width=40, got %d", l.origin)
+	}
 	if l.project != expected {
 		t.Errorf("expected project=%d, got %d", expected, l.project)
+	}
+}
+
+func TestCalcSessionLayout_OriginDropsAtBoundary(t *testing.T) {
+	// At exactly the threshold, origin should appear; one below, it should vanish.
+	lOn := calcSessionLayout(originColumnMinTTY)
+	if lOn.origin != fixedOriginWidth {
+		t.Errorf("expected origin=%d at width=%d, got %d", fixedOriginWidth, originColumnMinTTY, lOn.origin)
+	}
+	lOff := calcSessionLayout(originColumnMinTTY - 1)
+	if lOff.origin != 0 {
+		t.Errorf("expected origin=0 at width=%d, got %d", originColumnMinTTY-1, lOff.origin)
 	}
 }
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -42,17 +42,29 @@ func RenderList(sessions []session.Session) {
 	l := calcSessionLayout(getTerminalWidth())
 
 	// Header
-	header := fmt.Sprintf("%-*s %-*s %-*s %-*s",
-		l.status, "STATUS",
-		l.project, "PROJECT",
-		l.context, "CONTEXT",
-		l.activity, "LAST ACTIVITY")
-	fmt.Println(header)
+	fmt.Println(sessionHeader(l))
 	fmt.Println(strings.Repeat("─", l.totalWidth))
 
 	for _, s := range sessions {
 		renderSessionRow(s, l, "\n")
 	}
+}
+
+// sessionHeader returns the column header row matching the given layout.
+func sessionHeader(l sessionLayout) string {
+	if l.origin > 0 {
+		return fmt.Sprintf("%-*s %-*s %-*s %-*s %-*s",
+			l.status, "STATUS",
+			l.project, "PROJECT",
+			l.origin, "ORIGIN",
+			l.context, "CONTEXT",
+			l.activity, "LAST ACTIVITY")
+	}
+	return fmt.Sprintf("%-*s %-*s %-*s %-*s",
+		l.status, "STATUS",
+		l.project, "PROJECT",
+		l.context, "CONTEXT",
+		l.activity, "LAST ACTIVITY")
 }
 
 // RenderJSON renders sessions as JSON
@@ -100,12 +112,7 @@ func RenderLive(sessions []session.Session, webURL string, claudeStatus *session
 		l := calcSessionLayout(getTerminalWidth())
 
 		// Column headers
-		header := fmt.Sprintf("%-*s %-*s %-*s %-*s",
-			l.status, "STATUS",
-			l.project, "PROJECT",
-			l.context, "CONTEXT",
-			l.activity, "LAST ACTIVITY")
-		fmt.Printf("%s\r\n", header)
+		fmt.Printf("%s\r\n", sessionHeader(l))
 		fmt.Printf("%s\r\n", strings.Repeat("─", l.totalWidth))
 
 		for _, s := range active {
@@ -336,8 +343,36 @@ func formatContext(s session.Session, width int) string {
 	return bar
 }
 
+// formatOrigin renders the session origin cell, padded to exactly width visible chars.
+// Returns an empty string when the column is disabled (width == 0).
+func formatOrigin(o session.Origin, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	text := o.Display
+	if text == "" {
+		text = "-"
+	}
+	if len(text) > width {
+		text = text[:width]
+	}
+	padding := strings.Repeat(" ", width-len(text))
+	var color string
+	switch o.Category {
+	case session.OriginTerminal:
+		color = Gray
+	case session.OriginIDE:
+		color = Blue
+	case session.OriginDesktop:
+		color = Yellow
+	default:
+		color = Dim
+	}
+	return color + text + Reset + padding
+}
+
 // renderSessionRow renders a single session row using the given layout.
-// The main row shows status, project, context, and activity.
+// The main row shows status, project, origin (optional), context, and activity.
 // A second indented line shows the last message using the full width.
 func renderSessionRow(s session.Session, l sessionLayout, nl string) {
 	activity := formatElapsed(time.Since(s.LastActivity))
@@ -345,11 +380,21 @@ func renderSessionRow(s session.Session, l sessionLayout, nl string) {
 		activity = "Now"
 	}
 
-	row := fmt.Sprintf("%s %s %s %-*s",
-		formatStatus(s.Status, l.status),
-		formatProject(s, l.project),
-		formatContext(s, l.context),
-		l.activity, activity)
+	var row string
+	if l.origin > 0 {
+		row = fmt.Sprintf("%s %s %s %s %-*s",
+			formatStatus(s.Status, l.status),
+			formatProject(s, l.project),
+			formatOrigin(s.Origin, l.origin),
+			formatContext(s, l.context),
+			l.activity, activity)
+	} else {
+		row = fmt.Sprintf("%s %s %s %-*s",
+			formatStatus(s.Status, l.status),
+			formatProject(s, l.project),
+			formatContext(s, l.context),
+			l.activity, activity)
+	}
 	fmt.Print(row + nl)
 
 	// Second line: last message aligned with status text (after "● ")
@@ -412,12 +457,6 @@ func formatProject(s session.Session, maxLen int) string {
 	if s.HasUnsandboxed {
 		suffixes = append(suffixes, Yellow+"[!S]"+Reset)
 		suffixLens = append(suffixLens, 4) // [!S]
-	}
-
-	// Desktop indicator (lowest priority)
-	if s.IsDesktop {
-		suffixes = append(suffixes, Dim+"[D]"+Reset)
-		suffixLens = append(suffixLens, 3) // [D]
 	}
 
 	// Drop suffixes from the end until they fit, keeping at least 4 chars for the name

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -185,6 +185,7 @@
                     ${stoppedBadge}
                     ${s.git_branch ? `<span class="session-branch">${esc(s.git_branch)}</span>` : ''}
                     ${s.session_title ? `<span class="session-title">${esc(s.session_title)}</span>` : ''}
+                    ${s.origin && s.origin.category ? `<span class="session-origin origin-${esc(s.origin.category)}" title="${esc(s.origin.app || '')}">${esc(s.origin.display || s.origin.app || '')}</span>` : ''}
                     <span class="session-context">
                         <span class="context-bar"><span class="context-fill ${ctxCls}" style="width:${Math.min(pct, 100)}%"></span></span>
                         <span>${pct > 0 ? Math.round(pct) + '%' : '-'}</span>

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -409,7 +409,6 @@ main {
     border-radius: 3px;
     flex-shrink: 0;
     white-space: nowrap;
-    text-transform: lowercase;
     border: 1px solid currentColor;
     opacity: 0.85;
 }

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -403,6 +403,21 @@ main {
 .session-title::before { content: '"'; }
 .session-title::after { content: '"'; }
 
+.session-origin {
+    font-size: 0.7rem;
+    padding: 1px 6px;
+    border-radius: 3px;
+    flex-shrink: 0;
+    white-space: nowrap;
+    text-transform: lowercase;
+    border: 1px solid currentColor;
+    opacity: 0.85;
+}
+
+.session-origin.origin-terminal { color: var(--muted); }
+.session-origin.origin-ide      { color: var(--blue); }
+.session-origin.origin-desktop  { color: var(--yellow); }
+
 .session-context {
     flex-shrink: 0;
     display: flex;


### PR DESCRIPTION
## Summary

Adds an **Origin** column / badge that tells you where each Claude Code session was launched from — a terminal emulator (Ghostty, iTerm, Terminal.app, WezTerm, Kitty, Alacritty, Konsole, GNOME Terminal, …), **Claude Desktop**, or an IDE (Zed, VS Code, Cursor, VSCodium, JetBrains).

- JSONL logs don't record this, so detection walks the live Claude process's parent chain and inspects its environment (`TERM_PROGRAM`, `__CFBundleIdentifier`, `VSCODE_INJECTION`, `ZED_TERM`, `CURSOR_TRACE_ID`, …).
- Results are snapshotted to `~/.claude-monitor/origins/<sessionId>.json` so the badge persists after the session ends. Historical sessions seen before this feature existed will show `—` until they're run again.
- Platform detection is isolated behind build tags: macOS uses `ps -E -ww` + `ps -o ppid=,comm=`, Linux uses `/proc/<pid>/environ` + `/proc/<pid>/status` + `/proc/<pid>/exe`.
- Precedence: IDE env → IDE ancestor → terminal env → terminal ancestor → Claude Desktop (strict `Claude.app` bundle match, skipping the Claude CLI process itself) → Unknown.
- Terminal dashboard: new fixed-width `ORIGIN` column between Project and Context; drops out gracefully below 90 columns. The now-redundant `[D]` suffix is removed.
- Web dashboard: `.session-origin` badge colored by category (terminal=muted, ide=blue, desktop=yellow). The `origin` object is also included in REST/SSE payloads.
- 18 unit tests cover the classifier (including a regression case for the real-world Ghostty+Claude chain where `comm="claude"` previously misclassified as Claude Desktop) plus save/load round-trip for the persistence store.

### Screenshot

```
STATUS          PROJECT                             ORIGIN     CONTEXT          LAST ACTIVITY
─────────────────────────────────────────────────────────────────────────────────────────────
● Working       myorg/api-server @main              Ghostty    ███████░░░ 68%   Now
▲ Needs Input   work/claude-sessions-monitor @feat  Zed        ██░░░░░░░░ 21%   12s ago
```

## Test plan

- [ ] `go test ./...` — all tests pass on darwin
- [ ] `GOOS=linux go build ./...` — cross-compiles clean on linux/amd64 and linux/arm64
- [ ] `go vet ./...` — clean
- [ ] Run `csm -l` from Ghostty / iTerm / Terminal.app / Zed / VS Code / Cursor / Claude Desktop and confirm each live session shows the correct ORIGIN value in the column
- [ ] Verify `~/.claude-monitor/origins/<sessionId>.json` is written the first time a live session is seen and re-read on subsequent runs
- [ ] Exit a Claude process and confirm its session still shows the cached origin on the next `csm` refresh
- [ ] Resize terminal to 80 cols, confirm the ORIGIN column drops out and the project column expands
- [ ] `csm --web-only`, hit `/api/sessions`, confirm each session has an `origin` object with `category`, `app`, `display`
- [ ] Open the web dashboard and confirm the origin badge renders with the correct color per category

Generated with [Claude Code](https://claude.com/claude-code)