### PR TITLE
feat: add .deb and .rpm Linux packages (#36)

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -69,6 +69,16 @@ jobs:
       - name: Build binaries
         run: make build-all
 
+      - name: Install nfpm
+        env:
+          NFPM_VERSION: 2.46.3
+        run: |
+          curl -sSL -o /tmp/nfpm.deb "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_amd64.deb"
+          sudo dpkg -i /tmp/nfpm.deb
+
+      - name: Build Linux packages
+        run: make packages
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -78,6 +88,10 @@ jobs:
             dist/csm-darwin-arm64
             dist/csm-linux-amd64
             dist/csm-linux-arm64
+            dist/csm_*_amd64.deb
+            dist/csm_*_arm64.deb
+            dist/csm-*.x86_64.rpm
+            dist/csm-*.aarch64.rpm
           generate_release_notes: true
 
       - name: Update Homebrew formula

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,16 @@ jobs:
       - name: Build binaries
         run: make build-all
 
+      - name: Install nfpm
+        env:
+          NFPM_VERSION: 2.46.3
+        run: |
+          curl -sSL -o /tmp/nfpm.deb "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_amd64.deb"
+          sudo dpkg -i /tmp/nfpm.deb
+
+      - name: Build Linux packages
+        run: make packages
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -32,6 +42,10 @@ jobs:
             dist/csm-darwin-arm64
             dist/csm-linux-amd64
             dist/csm-linux-arm64
+            dist/csm_*_amd64.deb
+            dist/csm_*_arm64.deb
+            dist/csm-*.x86_64.rpm
+            dist/csm-*.aarch64.rpm
           generate_release_notes: true
 
       - name: Update Homebrew formula

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Native `.deb` and `.rpm` Linux packages published with each release (amd64 and arm64)
 - Origin column showing where each session was launched from — terminal emulator (Ghostty, iTerm, Terminal.app, WezTerm, Kitty, Alacritty, Konsole, GNOME Terminal, ...), Claude Desktop, or IDE (Zed, VS Code, Cursor, VSCodium, JetBrains). Detection walks the Claude process's parent chain and inspects its environment; results are snapshotted to `~/.claude-monitor/origins/<sessionId>.json` so the badge persists after the session ends. The column is shown in both the terminal dashboard (drops out gracefully below 90 columns) and the web dashboard, and is also included in the JSON/SSE API responses.
 - Linux process detection via `/proc/<pid>/cwd` — live session status now works correctly on Linux without requiring `lsof`
 - Project naming from `cwd` field in JSONL logs — accurate, lossless project names on all platforms (replaces heuristic decoding of encoded directory names)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: build build-all install menubar menubar-release menubar-app menubar-install clean
+.PHONY: build build-all install menubar menubar-release menubar-app menubar-install packages clean
 
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS := -ldflags "-X main.version=$(VERSION)"
+
+# nfpm requires a version starting with a digit (deb policy), so strip any leading 'v'.
+PKG_VERSION := $(patsubst v%,%,$(VERSION))
 
 # Build for current platform
 build:
@@ -38,6 +41,17 @@ menubar-install: menubar-app
 	cp -r macos/CSMMenuBar/.build/CSMMenuBar.app /Applications/
 	xattr -d com.apple.quarantine /Applications/CSMMenuBar.app 2>/dev/null || true
 	@echo "Installed CSMMenuBar.app to /Applications/"
+
+# Build .deb and .rpm Linux packages for amd64 and arm64.
+# Requires `nfpm` on PATH (see .github/workflows for the pinned version used in CI).
+packages: build-all
+	@command -v nfpm >/dev/null 2>&1 || { echo >&2 "nfpm not found. Install from https://nfpm.goreleaser.com/install/"; exit 1; }
+	@for arch in amd64 arm64; do \
+		for pkg in deb rpm; do \
+			echo "Building csm $(PKG_VERSION) $$arch $$pkg"; \
+			VERSION=$(PKG_VERSION) ARCH=$$arch nfpm package --config nfpm.yaml --packager $$pkg --target dist/ || exit 1; \
+		done; \
+	done
 
 # Clean build artifacts
 clean:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ sudo mv csm /usr/local/bin/
 
 **macOS:** Use Homebrew (above) or download `csm-darwin-amd64` / `csm-darwin-arm64` from releases.
 
+### Debian / Ubuntu (.deb)
+
+Grab the `.deb` matching your architecture from the [latest release](https://github.com/yepzdk/claude-sessions-monitor/releases/latest) and install with `dpkg`. The asset filename is `csm_<version>_<arch>.deb`:
+
+```bash
+# replace X.Y.Z with the release version, e.g. 0.6.0
+VERSION=X.Y.Z
+ARCH=amd64   # or arm64
+curl -LO "https://github.com/yepzdk/claude-sessions-monitor/releases/download/v${VERSION}/csm_${VERSION}_${ARCH}.deb"
+sudo dpkg -i "csm_${VERSION}_${ARCH}.deb"
+```
+
+### Fedora / RHEL (.rpm)
+
+Asset filename is `csm-<version>.<arch>.rpm` (arch is `x86_64` or `aarch64`):
+
+```bash
+VERSION=X.Y.Z
+ARCH=x86_64   # or aarch64
+sudo rpm -i "https://github.com/yepzdk/claude-sessions-monitor/releases/download/v${VERSION}/csm-${VERSION}.${ARCH}.rpm"
+```
+
 ### Build from source
 
 ```bash

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://nfpm.goreleaser.com/schema.json
+#
+# nfpm config for building csm .deb and .rpm packages.
+# VERSION and ARCH are expected to be set in the environment by the Makefile
+# (VERSION must not start with 'v' — deb requires the version to start with a digit).
+
+name: csm
+arch: ${ARCH}
+platform: linux
+version: ${VERSION}
+version_schema: semver
+section: utils
+priority: optional
+maintainer: Jesper Pedersen <pejes@aarhus.dk>
+description: |
+  Claude Sessions Monitor — a lightweight CLI to monitor Claude Code sessions
+  across multiple projects, with live dashboard, web dashboard, and history view.
+vendor: yepzdk
+homepage: https://github.com/yepzdk/claude-sessions-monitor
+license: MIT
+
+contents:
+  - src: ./dist/csm-linux-${ARCH}
+    dst: /usr/bin/csm
+    expand: true
+    file_info:
+      mode: 0755
+      owner: root
+      group: root


### PR DESCRIPTION
## Summary

- Publish native `.deb` and `.rpm` Linux packages (amd64 + arm64) with every release via [nfpm](https://nfpm.goreleaser.com/)
- New `nfpm.yaml` + `make packages` target; both release workflows now install a pinned nfpm and attach the four package artifacts to the GitHub release
- README gains Debian/Ubuntu and Fedora/RHEL install sections; CHANGELOG updated

Closes #36.

### Design notes

- Went with standalone **nfpm** rather than full GoReleaser — the existing pipeline (Makefile + 2 workflows + Homebrew dispatch + menu bar app) already works, and nfpm is a minimal wrapper that leaves everything else untouched. If we later want full GoReleaser, this is a clean stepping stone.
- nfpm version pinned to `2.46.3` in both workflows.
- No signed apt/dnf repo yet — out of scope; this PR is the prerequisite for that work.

## Test plan

- [x] `make packages` produces all four artifacts locally (verified via Docker)
- [x] `.deb` installs on `debian:stable-slim`, `csm --help` runs, `dpkg-deb -I` metadata correct
- [x] `.rpm` installs on `fedora:latest`, `csm --help` runs, `rpm -qip` metadata correct
- [ ] After merge: confirm `auto-tag.yaml` run uploads the four new assets to the auto-created release
- [ ] Smoke-test the README install commands against a real tagged release

🤖 Generated with [Claude Code](https://claude.com/claude-code)