### PR TITLE
fix: detect 1M context window for Opus/Sonnet 4.6+ generations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Active model id is now exposed on the session JSON/SSE API and indicated in both dashboards: the terminal shows a dim `(1M)` suffix on the context cell when the session is using an extended context window, and the web dashboard shows a small `1M` badge with the full model id on hover
 - Native `.deb` and `.rpm` Linux packages published with each release (amd64 and arm64)
 - Origin column showing where each session was launched from — terminal emulator (Ghostty, iTerm, Terminal.app, WezTerm, Kitty, Alacritty, Konsole, GNOME Terminal, ...), Claude Desktop, or IDE (Zed, VS Code, Cursor, VSCodium, JetBrains). Detection walks the Claude process's parent chain and inspects its environment; results are snapshotted to `~/.claude-monitor/origins/<sessionId>.json` so the badge persists after the session ends. The column is shown in both the terminal dashboard (drops out gracefully below 90 columns) and the web dashboard, and is also included in the JSON/SSE API responses.
 - Linux process detection via `/proc/<pid>/cwd` — live session status now works correctly on Linux without requiring `lsof`
@@ -31,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Multi-tool_use detection: all tool calls in an assistant message are now checked, not just the first
 - Extended assistant "Working" window from 30 seconds to 2 minutes to reduce false "Waiting" during brief log gaps
 - Use log file modification time to detect active streaming writes, preventing "Waiting" during early response generation
-- Context percentage now uses model-specific context window sizes (Opus 4.6 and Sonnet 4.6 use 1M, others use 200K)
+- Context percentage now correctly recognises 1M-context models from Opus/Sonnet generation 4.6 onward (e.g. `claude-opus-4-7`, `claude-sonnet-4-7`, future generations); previously only `opus-4-6` and `sonnet-4-6` were detected, so newer models were treated as 200K and reported up to 5× too high
 
 ### Added
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -44,6 +45,7 @@ type Session struct {
 	HasUnsandboxed bool      `json:"has_unsandboxed,omitempty"` // True if any command bypassed sandbox
 	ContextPercent float64   `json:"context_percent,omitempty"` // Percentage of context window used
 	ContextTokens  int       `json:"context_tokens,omitempty"`  // Total input tokens from last usage entry
+	Model          string    `json:"model,omitempty"`           // Model id from the latest assistant usage (e.g. "claude-opus-4-7")
 	SessionTitle   string    `json:"session_title,omitempty"`   // Custom title set by user/Claude
 }
 
@@ -571,7 +573,7 @@ func parseSession(projectName, logFile string, pids []int) (Session, error) {
 	session.HasUnsandboxed = detectUnsandboxedCommands(entries)
 
 	// Extract context usage
-	session.ContextPercent, session.ContextTokens = extractContextUsage(entries)
+	session.ContextPercent, session.ContextTokens, session.Model = extractContextUsage(entries)
 
 	// Determine status from log entries
 	session.Status, session.Task, session.IsGhost = determineStatus(entries, isRunning, info.ModTime())
@@ -691,11 +693,11 @@ func detectUnsandboxedCommands(entries []LogEntry) bool {
 	return false
 }
 
-// extractContextUsage extracts context usage from the last assistant entry with usage data
-// Returns the percentage of context window used and total input tokens.
+// extractContextUsage extracts context usage from the last assistant entry with usage data.
+// Returns the percentage of context window used, total input tokens, and the model id.
 // Only considers entries after the most recent compact/microcompact boundary,
 // since context is reset during compaction.
-func extractContextUsage(entries []LogEntry) (float64, int) {
+func extractContextUsage(entries []LogEntry) (float64, int, string) {
 	// Find the most recent compact/microcompact boundary
 	lastBoundaryIdx := -1
 	for i := len(entries) - 1; i >= 0; i-- {
@@ -725,10 +727,10 @@ func extractContextUsage(entries []LogEntry) (float64, int) {
 
 		window := contextWindowForModel(entry.Message.Model)
 		percent := float64(totalTokens) / float64(window) * 100
-		return percent, totalTokens
+		return percent, totalTokens, entry.Message.Model
 	}
 
-	return 0, 0
+	return 0, 0, ""
 }
 
 // decodeProjectName converts the directory name to a readable project name
@@ -809,17 +811,57 @@ func readLastEntries(filePath string, count int) ([]LogEntry, error) {
 // DefaultContextWindow is the fallback context window size for Claude models (200K tokens)
 const DefaultContextWindow = 200000
 
+// ExtendedContextWindow is the 1M context window available on Opus/Sonnet from
+// generation 4.6 onward.
+const ExtendedContextWindow = 1_000_000
+
+// ContextWindowForModel is the exported variant of contextWindowForModel,
+// for use by the UI layer to label the active context window.
+func ContextWindowForModel(model string) int {
+	return contextWindowForModel(model)
+}
+
 // contextWindowForModel returns the context window size for a given model ID.
-// Opus 4.6 and Sonnet 4.6 have 1M context windows; all others default to 200K.
+// Opus and Sonnet from generation 4.6 onward have 1M context windows; Haiku and
+// older models use the 200K default.
 func contextWindowForModel(model string) int {
-	switch {
-	case strings.Contains(model, "opus-4-6"):
-		return 1_000_000
-	case strings.Contains(model, "sonnet-4-6"):
-		return 1_000_000
-	default:
+	family, major, minor, ok := parseClaudeModel(model)
+	if !ok {
 		return DefaultContextWindow
 	}
+	if family != "opus" && family != "sonnet" {
+		return DefaultContextWindow
+	}
+	if major > 4 || (major == 4 && minor >= 6) {
+		return ExtendedContextWindow
+	}
+	return DefaultContextWindow
+}
+
+// parseClaudeModel extracts the family ("opus", "sonnet", "haiku") and the
+// generation (major, minor) from model ids of the form
+// "claude-<family>-<major>-<minor>[-suffix]". Returns ok=false for anything
+// that doesn't match — including "<synthetic>", empty strings, and unknown
+// families — so callers can fall back to a safe default.
+func parseClaudeModel(model string) (family string, major, minor int, ok bool) {
+	const prefix = "claude-"
+	if !strings.HasPrefix(model, prefix) {
+		return "", 0, 0, false
+	}
+	parts := strings.Split(model[len(prefix):], "-")
+	if len(parts) < 3 {
+		return "", 0, 0, false
+	}
+	family = parts[0]
+	maj, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", 0, 0, false
+	}
+	min, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return "", 0, 0, false
+	}
+	return family, maj, min, true
 }
 
 // GhostThreshold is the duration after which a running process with no log activity

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -12,6 +12,7 @@ func TestExtractContextUsage(t *testing.T) {
 		entries        []LogEntry
 		wantPercent    float64
 		wantTokens     int
+		wantModel      string
 		wantHasContext bool
 	}{
 		{
@@ -58,6 +59,7 @@ func TestExtractContextUsage(t *testing.T) {
 			},
 			wantPercent:    2.051, // (10 + 1000 + 19000 + 500) / 1000000 * 100 (opus-4-6 = 1M)
 			wantTokens:     20510,
+			wantModel:      "claude-opus-4-6",
 			wantHasContext: true,
 		},
 		{
@@ -93,6 +95,7 @@ func TestExtractContextUsage(t *testing.T) {
 			},
 			wantPercent:    4.021, // (10 + 1000 + 39000 + 200) / 1000000 * 100 (opus-4-6 = 1M)
 			wantTokens:     40210,
+			wantModel:      "claude-opus-4-6",
 			wantHasContext: true,
 		},
 		{
@@ -114,6 +117,7 @@ func TestExtractContextUsage(t *testing.T) {
 			},
 			wantPercent:    18.11, // (100 + 10000 + 170000 + 1000) / 1000000 * 100 (opus-4-6 = 1M)
 			wantTokens:     181100,
+			wantModel:      "claude-opus-4-6",
 			wantHasContext: true,
 		},
 		{
@@ -193,6 +197,7 @@ func TestExtractContextUsage(t *testing.T) {
 			},
 			wantPercent:    2.051, // (10 + 1000 + 19000 + 500) / 1000000 * 100 (opus-4-6 = 1M)
 			wantTokens:     20510,
+			wantModel:      "claude-opus-4-6",
 			wantHasContext: true,
 		},
 		{
@@ -214,13 +219,36 @@ func TestExtractContextUsage(t *testing.T) {
 			},
 			wantPercent:    10.255, // (10 + 1000 + 19000 + 500) / 200000 * 100 (haiku = 200K)
 			wantTokens:     20510,
+			wantModel:      "claude-haiku-4-5-20251001",
+			wantHasContext: true,
+		},
+		{
+			name: "opus-4-7 uses 1M context window",
+			entries: []LogEntry{
+				{
+					Type: "assistant",
+					Message: &Message{
+						Role:  "assistant",
+						Model: "claude-opus-4-7",
+						Usage: &Usage{
+							InputTokens:              200,
+							CacheCreationInputTokens: 15000,
+							CacheReadInputTokens:     228000,
+							OutputTokens:             515,
+						},
+					},
+				},
+			},
+			wantPercent:    24.3715, // 243715 / 1000000 * 100
+			wantTokens:     243715,
+			wantModel:      "claude-opus-4-7",
 			wantHasContext: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			percent, tokens := extractContextUsage(tt.entries)
+			percent, tokens, model := extractContextUsage(tt.entries)
 			hasContext := tokens > 0
 
 			if hasContext != tt.wantHasContext {
@@ -229,6 +257,10 @@ func TestExtractContextUsage(t *testing.T) {
 
 			if tokens != tt.wantTokens {
 				t.Errorf("tokens = %d, want %d", tokens, tt.wantTokens)
+			}
+
+			if model != tt.wantModel {
+				t.Errorf("model = %q, want %q", model, tt.wantModel)
 			}
 
 			// Compare percentages with small tolerance for floating point
@@ -246,12 +278,20 @@ func TestContextWindowForModel(t *testing.T) {
 		want  int
 	}{
 		{"claude-opus-4-6", 1_000_000},
-		{"opus", 200_000},
+		{"claude-opus-4-7", 1_000_000},
 		{"claude-sonnet-4-6", 1_000_000},
+		{"claude-sonnet-4-7", 1_000_000},
+		{"claude-opus-5-0", 1_000_000},
+		{"claude-sonnet-10-0", 1_000_000},
+		{"opus", 200_000},
 		{"sonnet", 200_000},
 		{"claude-haiku-4-5-20251001", 200_000},
+		{"claude-haiku-4-7", 200_000},
 		{"haiku", 200_000},
+		{"claude-opus-4-5", 200_000},
 		{"claude-sonnet-4-5-20250929", 200_000},
+		{"claude-opus-3-7", 200_000},
+		{"<synthetic>", 200_000},
 		{"", 200_000},
 		{"unknown-model", 200_000},
 	}

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -4,7 +4,7 @@ package ui
 const (
 	fixedStatusWidth   = 14 // "● Needs Input" = 13 chars + 1 padding
 	fixedOriginWidth   = 10 // "Claude Desktop" truncated; most origins fit in 9
-	fixedContextWidth  = 16 // progress bar (10) + " 100%" (5) + 1 padding
+	fixedContextWidth  = 21 // progress bar (10) + " 100%" (5) + " (1M)" suffix (5) + 1 padding
 	fixedActivityWidth = 15 // "LAST ACTIVITY" header + padding
 	minProjectWidth    = 15
 	originColumnMinTTY = 90 // drop the origin column below this terminal width

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -11,8 +11,8 @@ func TestCalcSessionLayout_WideTerminal(t *testing.T) {
 	if l.origin != fixedOriginWidth {
 		t.Errorf("expected origin=%d, got %d", fixedOriginWidth, l.origin)
 	}
-	if l.context != 16 {
-		t.Errorf("expected context=16, got %d", l.context)
+	if l.context != fixedContextWidth {
+		t.Errorf("expected context=%d, got %d", fixedContextWidth, l.context)
 	}
 	if l.activity != 15 {
 		t.Errorf("expected activity=15, got %d", l.activity)

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -330,12 +330,23 @@ func formatContext(s session.Session, width int) string {
 
 	// Build bar: colored filled blocks + dim empty blocks + percentage
 	label := fmt.Sprintf(" %.0f%%", pct)
+
+	// Append a marker when the active model uses an extended context window so
+	// users can tell at a glance that "24%" is of 1M, not 200K.
+	suffix := ""
+	if session.ContextWindowForModel(s.Model) > session.DefaultContextWindow {
+		suffix = " (1M)"
+	}
+
 	bar := color + strings.Repeat("█", filled) + Reset +
 		Dim + strings.Repeat("░", empty) + Reset +
 		label
+	if suffix != "" {
+		bar += Dim + suffix + Reset
+	}
 
-	// Pad to width (visible length = bar chars + label chars)
-	visibleLen := contextBarWidth + len(label)
+	// Pad to width (visible length = bar chars + label chars + suffix chars)
+	visibleLen := contextBarWidth + len(label) + len(suffix)
 	if visibleLen < width {
 		bar += strings.Repeat(" ", width-visibleLen)
 	}

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -185,8 +185,9 @@
                     ${stoppedBadge}
                     ${s.git_branch ? `<span class="session-branch">${esc(s.git_branch)}</span>` : ''}
                     ${s.session_title ? `<span class="session-title">${esc(s.session_title)}</span>` : ''}
-                    ${s.origin && s.origin.category ? `<span class="session-origin origin-${esc(s.origin.category)}" title="${esc(s.origin.app || '')}">${esc(s.origin.display || s.origin.app || '')}</span>` : ''}
-                    <span class="session-context">
+                    ${s.origin && s.origin.category ? `<span class="badge session-origin origin-${esc(s.origin.category)}" title="${esc(s.origin.app || '')}">${esc(s.origin.display || s.origin.app || '')}</span>` : ''}
+                    ${isExtendedContextModel(s.model) ? `<span class="badge session-model-badge" title="${esc(s.model)}">1M</span>` : ''}
+                    <span class="session-context" title="${esc(s.model || '')}">
                         <span class="context-bar"><span class="context-fill ${ctxCls}" style="width:${Math.min(pct, 100)}%"></span></span>
                         <span>${pct > 0 ? Math.round(pct) + '%' : '-'}</span>
                     </span>
@@ -738,5 +739,18 @@
         const d = document.createElement('div');
         d.textContent = s;
         return d.innerHTML;
+    }
+
+    // Mirrors session.contextWindowForModel in Go: opus/sonnet from generation 4.6
+    // onward use the 1M extended context window.
+    function isExtendedContextModel(model) {
+        if (!model) return false;
+        const m = /^claude-(opus|sonnet|haiku)-(\d+)-(\d+)/.exec(model);
+        if (!m) return false;
+        const family = m[1];
+        const major = parseInt(m[2], 10);
+        const minor = parseInt(m[3], 10);
+        if (family !== 'opus' && family !== 'sonnet') return false;
+        return major > 4 || (major === 4 && minor >= 6);
     }
 })();

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -403,19 +403,21 @@ main {
 .session-title::before { content: '"'; }
 .session-title::after { content: '"'; }
 
-.session-origin {
+.badge {
     font-size: 0.7rem;
     padding: 1px 6px;
     border-radius: 3px;
+    border: 1px solid currentColor;
     flex-shrink: 0;
     white-space: nowrap;
-    border: 1px solid currentColor;
     opacity: 0.85;
 }
 
 .session-origin.origin-terminal { color: var(--muted); }
 .session-origin.origin-ide      { color: var(--blue); }
 .session-origin.origin-desktop  { color: var(--yellow); }
+
+.session-model-badge { color: var(--muted); }
 
 .session-context {
     flex-shrink: 0;


### PR DESCRIPTION
## Summary

- The model→window mapping only matched the literal strings `opus-4-6` and `sonnet-4-6`, so newer models (e.g. `claude-opus-4-7`) fell through to the 200K default. A session at 243,715 tokens showed **100%** in csm while Claude Code itself reported the correct **24%**.
- Replaced the hardcoded checks with a small `parseClaudeModel` helper. Opus/Sonnet at generation ≥ 4.6 are recognised as 1M, future generations included. Haiku and older models keep the 200K default.
- Surfaced the active model so the same kind of mismatch is diagnosable at a glance:
  - exposed `Model` on the `Session` JSON / SSE API
  - terminal: dim `(1M)` suffix on the context cell when the session uses the extended window
  - web: small `1M` badge next to the origin badge, with the full model id shown on hover; shared styling extracted into a reusable `.badge` class

## Test plan

- [x] `go test ./...` passes (extended `TestContextWindowForModel` table covers `opus-4-7`, `sonnet-4-7`, `opus-5-0`, Haiku, pre-4.6, `<synthetic>`, empty)
- [x] Live verification against `claude-opus-4-7` session: csm now reports the same percentage as Claude Code's own status bar instead of 100%
- [ ] Reviewer: load the web dashboard and confirm origin and `1M` badges render at identical height/font

🤖 Generated with [Claude Code](https://claude.com/claude-code)