### PR TITLE
feat: smarter timeline Load more and clickable User Prompts card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Web dashboard: clicking the "User Prompts" metric card in the session detail modal now jumps to the Timeline tab with the `User` filter applied, scrolled to the first prompt
+- Web dashboard: timeline "Load more" escalates after the second click — the third click loads all remaining entries in one go (chunked server-side at 500 per request) instead of forcing repeated clicks
 - Active model id is now exposed on the session JSON/SSE API and indicated in both dashboards: the terminal shows a dim `(1M)` suffix on the context cell when the session is using an extended context window, and the web dashboard shows a small `1M` badge with the full model id on hover
 - Native `.deb` and `.rpm` Linux packages published with each release (amd64 and arm64)
 - Origin column showing where each session was launched from — terminal emulator (Ghostty, iTerm, Terminal.app, WezTerm, Kitty, Alacritty, Konsole, GNOME Terminal, ...), Claude Desktop, or IDE (Zed, VS Code, Cursor, VSCodium, JetBrains). Detection walks the Claude process's parent chain and inspects its environment; results are snapshotted to `~/.claude-monitor/origins/<sessionId>.json` so the badge persists after the session ends. The column is shown in both the terminal dashboard (drops out gracefully below 90 columns) and the web dashboard, and is also included in the JSON/SSE API responses.

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -452,12 +452,14 @@
     let timelineEntries = [];
     let currentLogFile = '';
     let timelineFilter = 'all'; // all, assistant, user
+    let timelineLoadMoreClicks = 0;
 
     function openDetail(logFile, project) {
         currentLogFile = logFile;
         timelineOffset = 0;
         timelineEntries = [];
         timelineFilter = 'all';
+        timelineLoadMoreClicks = 0;
         detailTitle.textContent = project;
         detailOverlay.classList.remove('hidden');
 
@@ -507,7 +509,7 @@
 
         let html = `<div class="metrics-grid">
             <div class="metric-card"><div class="metric-label">Turns</div><div class="metric-value blue">${m.turn_count}</div></div>
-            <div class="metric-card"><div class="metric-label">User Prompts</div><div class="metric-value green">${m.user_prompt_count}</div></div>
+            <div class="metric-card metric-clickable" data-action="show-user-prompts" title="Show user prompts in timeline"><div class="metric-label">User Prompts</div><div class="metric-value green">${m.user_prompt_count}</div></div>
             <div class="metric-card"><div class="metric-label">Tool Results</div><div class="metric-value">${m.tool_result_count}</div></div>
             <div class="metric-card"><div class="metric-label">Assistant Messages</div><div class="metric-value purple">${m.assistant_message_count}</div></div>
             <div class="metric-card"><div class="metric-label">Duration</div><div class="metric-value">${duration}</div></div>
@@ -545,22 +547,48 @@
         }
 
         detailMetrics.innerHTML = html;
+
+        const userPromptsCard = detailMetrics.querySelector('[data-action="show-user-prompts"]');
+        if (userPromptsCard) {
+            userPromptsCard.addEventListener('click', showUserPromptsTimeline);
+        }
     }
 
-    async function loadTimeline(logFile, reset) {
+    function showUserPromptsTimeline() {
+        document.querySelectorAll('.detail-tab').forEach(t => {
+            t.classList.toggle('active', t.dataset.detail === 'timeline');
+        });
+        detailMetrics.classList.remove('active');
+        detailTimeline.classList.add('active');
+
+        timelineFilter = 'user';
+        loadTimeline(currentLogFile, true, 'page').then(() => {
+            detailTimeline.scrollTop = 0;
+        });
+    }
+
+    async function loadTimeline(logFile, reset, mode = 'page') {
         if (reset) {
             timelineOffset = 0;
             timelineEntries = [];
+            timelineLoadMoreClicks = 0;
             detailTimeline.innerHTML = '<div class="loading">Loading timeline...</div>';
         }
 
+        const SERVER_MAX = 500;
         try {
-            const resp = await fetch(`/api/sessions/timeline?file=${encodeURIComponent(logFile)}&offset=${timelineOffset}&limit=50`);
-            if (!resp.ok) throw new Error(await resp.text());
-            const data = await resp.json();
-            timelineTotal = data.total;
-            timelineEntries = timelineEntries.concat(data.entries || []);
-            timelineOffset += (data.entries || []).length;
+            do {
+                const remaining = Math.max(1, timelineTotal - timelineOffset);
+                const limit = mode === 'all' ? Math.min(SERVER_MAX, remaining) : 50;
+                const resp = await fetch(`/api/sessions/timeline?file=${encodeURIComponent(logFile)}&offset=${timelineOffset}&limit=${limit}`);
+                if (!resp.ok) throw new Error(await resp.text());
+                const data = await resp.json();
+                timelineTotal = data.total;
+                const batch = data.entries || [];
+                timelineEntries = timelineEntries.concat(batch);
+                timelineOffset += batch.length;
+                if (batch.length === 0) break;
+            } while (mode === 'all' && timelineOffset < timelineTotal);
             renderTimeline();
         } catch (err) {
             detailTimeline.innerHTML = `<div class="empty-state">Failed to load timeline</div>`;
@@ -636,7 +664,11 @@
         html += '</div>';
 
         if (timelineOffset < timelineTotal) {
-            html += `<button class="load-more" id="load-more-btn">Load more (${timelineOffset}/${timelineTotal})</button>`;
+            const loadAll = timelineLoadMoreClicks >= 2;
+            const label = loadAll
+                ? `Load all remaining (${timelineTotal - timelineOffset})`
+                : `Load more (${timelineOffset}/${timelineTotal})`;
+            html += `<button class="load-more" id="load-more-btn" data-mode="${loadAll ? 'all' : 'page'}">${label}</button>`;
         }
 
         detailTimeline.innerHTML = html;
@@ -650,7 +682,11 @@
 
         const loadMoreBtn = document.getElementById('load-more-btn');
         if (loadMoreBtn) {
-            loadMoreBtn.addEventListener('click', () => loadTimeline(currentLogFile, false));
+            loadMoreBtn.addEventListener('click', () => {
+                const mode = loadMoreBtn.dataset.mode === 'all' ? 'all' : 'page';
+                timelineLoadMoreClicks += 1;
+                loadTimeline(currentLogFile, false, mode);
+            });
         }
     }
 

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -783,6 +783,17 @@ main {
     padding: 0.75rem;
 }
 
+.metric-card.metric-clickable {
+    cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.metric-card.metric-clickable:hover {
+    background: var(--bg-hover);
+    border-color: var(--green);
+    transform: translateY(-1px);
+}
+
 .metric-label {
     font-size: 0.6875rem;
     color: var(--text-dim);


### PR DESCRIPTION
## Summary

Two small UX improvements to the web dashboard's session detail modal:

- **Smarter timeline "Load more":** after the second click, the button changes to **"Load all remaining (N)"** and fetches the rest of the entries in one action (chunked server-side at the existing 500/request cap). Long sessions no longer require many repeat clicks.
- **Clickable "User Prompts" metric card:** clicking the card switches to the Timeline tab, activates the `User` filter, reloads from offset 0, and scrolls to the top — so the first/initial user prompt is visible immediately.
- Minor: hover affordance (`cursor: pointer`, hover background, green border, slight lift) for clickable metric cards.

No backend changes — uses the existing `/api/sessions/timeline` endpoint and its `limit` (max 500) param.

## Test plan

- [ ] `go build ./...` succeeds (verified locally)
- [ ] Open a project with a long session (>150 timeline entries) in the web dashboard
- [ ] Timeline tab: click "Load more" twice — entries grow by 50 each click, label stays "Load more"
- [ ] Third click: button reads "Load all remaining (X)" and clicking loads everything; button disappears at end
- [ ] Metrics tab: hover the "User Prompts" card — pointer cursor, subtle hover style
- [ ] Click the card: modal switches to Timeline, `User` filter is active, list starts at the first user prompt
- [ ] Close and reopen the modal for another project — Load-more click counter resets, behavior is per-session
- [ ] Escape still closes the modal; other metric cards remain non-clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)