### PR TITLE
feat: add `csm manage` tmux workspace skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `csm manage` subcommand — launches a tmux-driven workspace running the monitor view. Attaches to an existing `csm` tmux session if one is running, otherwise creates one (status bar hidden). Requires tmux; exits with an install hint if it's missing. Foundation for upcoming agent orchestration (spawning and switching between Claude sessions).
 - Web dashboard: clicking the "User Prompts" metric card in the session detail modal now jumps to the Timeline tab with the `User` filter applied, scrolled to the first prompt
 - Web dashboard: timeline "Load more" escalates after the second click — the third click loads all remaining entries in one go (chunked server-side at 500 per request) instead of forcing repeated clicks
 - Active model id is now exposed on the session JSON/SSE API and indicated in both dashboards: the terminal shows a dim `(1M)` suffix on the context cell when the session is using an extended context window, and the web dashboard shows a small `1M` badge with the full model id on hover

--- a/internal/manage/manage.go
+++ b/internal/manage/manage.go
@@ -1,0 +1,108 @@
+// Package manage implements the `csm manage` subcommand: a tmux-driven
+// workspace for running and switching between Claude agents. Slice 1 lays
+// the skeleton — preflight tmux, then attach to or create a session
+// running the standard monitor view. Agent spawning, the sidebar, and
+// worktrees follow in later slices.
+package manage
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"syscall"
+)
+
+// Single shared tmux session per host for now. Per-project sessions are a
+// reasonable future direction — change this to a function of cwd/projectID
+// and the attach-or-create flow keeps working.
+const sessionName = "csm"
+
+// Run is the entry point for `csm manage`. Preflights tmux, then either
+// attaches to an existing csm session or creates a fresh one running the
+// monitor view.
+func Run() error {
+	if err := preflightTmux(); err != nil {
+		return err
+	}
+	if sessionExists(sessionName) {
+		return attachExisting(sessionName)
+	}
+	return createAndAttach(sessionName)
+}
+
+func preflightTmux() error {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		return fmt.Errorf("tmux is required for `csm manage` but was not found on PATH.\n%s", installHint())
+	}
+	if out, err := exec.Command("tmux", "-V").CombinedOutput(); err != nil {
+		return fmt.Errorf("tmux is installed but failed to run: %w\noutput: %s", err, string(out))
+	}
+	return nil
+}
+
+func installHint() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "Install with: brew install tmux"
+	case "linux":
+		return "Install with your package manager, e.g.: sudo apt install tmux"
+	default:
+		return "See https://github.com/tmux/tmux/wiki for installation instructions."
+	}
+}
+
+func sessionExists(name string) bool {
+	err := exec.Command("tmux", "has-session", "-t", name).Run()
+	return err == nil
+}
+
+func attachExisting(name string) error {
+	return execTmux("attach", "-t", name)
+}
+
+func createAndAttach(name string) error {
+	bin, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate own binary: %w", err)
+	}
+
+	// Create the session detached, with a single pane running the
+	// standard monitor view. -x/-y give a baseline size so layout math
+	// doesn't operate on a 0x0 client at creation time.
+	if out, err := exec.Command("tmux",
+		"new-session", "-d",
+		"-s", name,
+		"-n", "main",
+		"-x", "200", "-y", "50",
+		bin,
+	).CombinedOutput(); err != nil {
+		return fmt.Errorf("tmux new-session failed: %w\noutput: %s", err, string(out))
+	}
+
+	// Hide the status bar for this session only — there's a single window
+	// in slice 1, so it's just noise. Slice 2 may re-enable it once the
+	// window switcher becomes useful.
+	if out, err := exec.Command("tmux",
+		"set-option", "-t", name, "status", "off",
+	).CombinedOutput(); err != nil {
+		return fmt.Errorf("tmux set-option status off failed: %w\noutput: %s", err, string(out))
+	}
+
+	return execTmux("attach", "-t", name)
+}
+
+// execTmux replaces the current process with `tmux <args...>`. On success
+// it does not return; on failure it returns an error.
+func execTmux(args ...string) error {
+	tmuxPath, err := exec.LookPath("tmux")
+	if err != nil {
+		return fmt.Errorf("tmux disappeared from PATH: %w", err)
+	}
+	argv := append([]string{"tmux"}, args...)
+	if err := syscall.Exec(tmuxPath, argv, os.Environ()); err != nil {
+		return fmt.Errorf("exec tmux: %w", err)
+	}
+	return errors.New("unreachable")
+}

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/itk-dev/claude-sessions-monitor/internal/manage"
 	"github.com/itk-dev/claude-sessions-monitor/internal/session"
 	"github.com/itk-dev/claude-sessions-monitor/internal/ui"
 	"github.com/itk-dev/claude-sessions-monitor/internal/web"
@@ -19,6 +20,15 @@ import (
 var version = "dev"
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "manage" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2:]...)
+		if err := manage.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "manage: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	// Parse flags
 	listOnce := flag.Bool("l", false, "List sessions once and exit")
 	jsonOutput := flag.Bool("json", false, "Output as JSON (requires -l)")


### PR DESCRIPTION
## Summary

Slice 1 of 3 toward turning `csm` into a session orchestrator. This PR adds the `csm manage` subcommand as a **layout skeleton only** — no agent spawning yet.

`csm manage`:
- Preflights tmux; exits with a clear, platform-aware install hint if tmux is missing.
- Attaches to an existing `csm` tmux session if one is running, otherwise creates a fresh one running the standard monitor view.
- Hides the tmux status bar for the `csm` session (single window for now — it's just noise; will be re-enabled in slice 2 when the window switcher becomes useful).
- Invokes the same binary via `os.Executable()` so the pane never runs a mismatched `csm` from PATH.

### What's intentionally NOT here (later slices)
- Agent spawning, project picker, `n` hotkey
- Git-worktree isolation (`~/.csm/worktrees/...`) per agent
- The sidebar / managed-vs-external session distinction
- Worktree cleanup prompts

The earlier single-pane picker and the compact sidebar renderer that were prototyped during design were removed — `csm manage` is repurposed, and the sidebar will be rebuilt as a proper narrow monitor view in slice 2 (only shown once there are managed agents).

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] Existing flows unchanged: `./csm`, `--web`, `-l`, `-history`, `-v`
- [x] Preflight error path shows the brew/apt install hint when tmux is off PATH
- [ ] Fresh `./csm manage` opens tmux running the monitor full-width, no status bar
- [ ] Detach (`Ctrl-b d`) then `./csm manage` re-attaches to the same session
- [ ] `tmux kill-session -t csm` returns cleanly to the shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)