### PR TITLE
feat: spawn agents into git worktrees from `csm manage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - `csm manage` subcommand — launches a tmux-driven workspace running the monitor view. Attaches to an existing `csm` tmux session if one is running, otherwise creates one (status bar hidden). Requires tmux; exits with an install hint if it's missing. Foundation for upcoming agent orchestration (spawning and switching between Claude sessions).
+- `csm manage`: press `Ctrl-n` to spawn a new agent — prompts for a project directory (defaulting to where `csm manage` was launched), creates an isolated git worktree at `~/.claude-monitor/worktrees/<project>/<agent>` on a `csm/<project>/<agent>` branch, and opens a new tmux window running `claude` there. Each agent is recorded under `~/.claude-monitor/managed/` so multiple agents on the same repo never tangle in one checkout.
 - Web dashboard: clicking the "User Prompts" metric card in the session detail modal now jumps to the Timeline tab with the `User` filter applied, scrolled to the first prompt
 - Web dashboard: timeline "Load more" escalates after the second click — the third click loads all remaining entries in one go (chunked server-side at 500 per request) instead of forcing repeated clicks
 - Active model id is now exposed on the session JSON/SSE API and indicated in both dashboards: the terminal shows a dim `(1M)` suffix on the context cell when the session is using an extended context window, and the web dashboard shows a small `1M` badge with the full model id on hover

--- a/internal/manage/git.go
+++ b/internal/manage/git.go
@@ -1,0 +1,35 @@
+package manage
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// isGitRepo reports whether dir is inside a git working tree.
+func isGitRepo(dir string) bool {
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "--git-dir")
+	return cmd.Run() == nil
+}
+
+// gitToplevel returns the absolute path to the root of the working tree
+// containing dir.
+func gitToplevel(dir string) (string, error) {
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse --show-toplevel in %q: %w", dir, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// worktreeAdd creates a new worktree at path on a fresh branch off HEAD.
+// Fails (without partial state) if the branch already exists or path is taken.
+func worktreeAdd(repo, branch, path string) error {
+	out, err := exec.Command("git", "-C", repo,
+		"worktree", "add", "-b", branch, path, "HEAD",
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git worktree add failed: %w\n%s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/manage/manage.go
+++ b/internal/manage/manage.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"syscall"
 )
@@ -81,16 +82,51 @@ func createAndAttach(name string) error {
 		return fmt.Errorf("tmux new-session failed: %w\noutput: %s", err, string(out))
 	}
 
-	// Hide the status bar for this session only — there's a single window
-	// in slice 1, so it's just noise. Slice 2 may re-enable it once the
-	// window switcher becomes useful.
+	// Hide the status bar — we don't have the agent-switching UX yet, so
+	// it's just noise. Slice 2b re-enables it when the sidebar uses it.
 	if out, err := exec.Command("tmux",
 		"set-option", "-t", name, "status", "off",
 	).CombinedOutput(); err != nil {
 		return fmt.Errorf("tmux set-option status off failed: %w\noutput: %s", err, string(out))
 	}
 
+	// Remember where `csm manage` was launched so the spawn prompt can
+	// default to the current project.
+	if cwd, err := os.Getwd(); err == nil {
+		_ = exec.Command("tmux", "set-environment", "-t", name, "CSM_PROJECT_ROOT", cwd).Run()
+	}
+
+	// Load the csm key bindings (Ctrl-n to spawn an agent). The bindings are
+	// server-global by tmux's nature; the helpers they invoke guard on being
+	// inside the csm session, so they're inert elsewhere.
+	if err := installBindings(name, bin); err != nil {
+		return err
+	}
+
 	return execTmux("attach", "-t", name)
+}
+
+// installBindings writes a generated tmux config with the csm key bindings
+// and sources it into the session.
+func installBindings(name, bin string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("unable to determine home directory: %w", err)
+	}
+	dir := filepath.Join(home, ".claude-monitor", "tmux")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create tmux config dir: %w", err)
+	}
+	conf := filepath.Join(dir, "bindings.conf")
+	// Root-table binding: plain Ctrl-n (no prefix) spawns an agent.
+	content := fmt.Sprintf("bind-key -n C-n run-shell \"%s __spawn\"\n", bin)
+	if err := os.WriteFile(conf, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("write bindings config: %w", err)
+	}
+	if out, err := exec.Command("tmux", "source-file", conf).CombinedOutput(); err != nil {
+		return fmt.Errorf("tmux source-file failed: %w\noutput: %s", err, string(out))
+	}
+	return nil
 }
 
 // execTmux replaces the current process with `tmux <args...>`. On success

--- a/internal/manage/spawn.go
+++ b/internal/manage/spawn.go
@@ -1,0 +1,163 @@
+package manage
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// agentCommand is the command launched in each managed agent window. The
+// single place that hardcodes "claude" — a future second agent type becomes
+// a choice here, not a scattered change.
+const agentCommand = "claude"
+
+// Spawn is invoked by the `csm __spawn` hidden subcommand, bound to <prefix>n
+// inside the csm tmux session.
+//
+// Two modes:
+//   - no args: open a tmux command-prompt (pre-filled with the launch dir)
+//     that re-invokes `csm __spawn <dir>` with the chosen project.
+//   - one arg: the chosen project dir — create the worktree and agent window.
+func Spawn(args []string) error {
+	if err := ensureInCSMSession(); err != nil {
+		return err
+	}
+	if len(args) == 0 {
+		return openProjectPrompt()
+	}
+	return spawnAgent(strings.TrimSpace(args[0]))
+}
+
+// ensureInCSMSession guards against the server-global key binding firing in
+// some other tmux session. The binding exists server-wide, but the helper
+// only acts inside the csm session.
+func ensureInCSMSession() error {
+	if os.Getenv("TMUX") == "" {
+		return fmt.Errorf("`csm __spawn` must run inside the csm tmux session (use `csm manage`)")
+	}
+	out, err := exec.Command("tmux", "display-message", "-p", "#{session_name}").Output()
+	if err != nil {
+		return fmt.Errorf("query tmux session name: %w", err)
+	}
+	if strings.TrimSpace(string(out)) != sessionName {
+		return fmt.Errorf("not in the %q tmux session", sessionName)
+	}
+	return nil
+}
+
+// openProjectPrompt shows a tmux command-prompt for the project directory,
+// defaulting to CSM_PROJECT_ROOT, then re-invokes this binary to do the work.
+func openProjectPrompt() error {
+	bin, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate own binary: %w", err)
+	}
+	def := tmuxSessionEnv("CSM_PROJECT_ROOT")
+	// %1 is replaced by tmux with the prompt answer.
+	runCmd := fmt.Sprintf("run-shell \"%s __spawn '%%1'\"", bin)
+	cmd := exec.Command("tmux", "command-prompt",
+		"-p", "Project dir:",
+		"-I", def,
+		runCmd,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("tmux command-prompt failed: %w\n%s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func spawnAgent(dir string) error {
+	if dir == "" {
+		return displayErr("no project directory given")
+	}
+	if !isGitRepo(dir) {
+		return displayErr(fmt.Sprintf("%s is not a git repository", dir))
+	}
+	repo, err := gitToplevel(dir)
+	if err != nil {
+		return displayErr(err.Error())
+	}
+	project := filepath.Base(repo)
+
+	name, err := nextAgentName(project)
+	if err != nil {
+		return displayErr(fmt.Sprintf("derive agent name: %v", err))
+	}
+	branch := fmt.Sprintf("csm/%s/%s", project, name)
+
+	worktree, err := worktreePath(project, name)
+	if err != nil {
+		return displayErr(err.Error())
+	}
+
+	if err := worktreeAdd(repo, branch, worktree); err != nil {
+		return displayErr(err.Error())
+	}
+
+	// Record before opening the window so a crash mid-spawn is recoverable.
+	agent := Agent{
+		Project:    project,
+		Name:       name,
+		Repo:       repo,
+		Worktree:   worktree,
+		Branch:     branch,
+		TmuxWindow: name,
+		CreatedAt:  time.Now(),
+	}
+	if err := SaveAgent(agent); err != nil {
+		return displayErr(fmt.Sprintf("save agent record: %v", err))
+	}
+
+	if err := openAgentWindow(agent); err != nil {
+		return displayErr(err.Error())
+	}
+	return nil
+}
+
+func worktreePath(project, name string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".claude-monitor", "worktrees", project, name), nil
+}
+
+func openAgentWindow(a Agent) error {
+	out, err := exec.Command("tmux", "new-window",
+		"-t", sessionName,
+		"-n", a.Name,
+		"-c", a.Worktree,
+		"-e", "CSM_MANAGED=1",
+		"-e", "CSM_AGENT="+a.Name,
+		agentCommand,
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("tmux new-window failed: %w\n%s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// tmuxSessionEnv reads a session environment variable set on the csm session,
+// returning "" if unset or on error.
+func tmuxSessionEnv(key string) string {
+	out, err := exec.Command("tmux", "show-environment", "-t", sessionName, key).Output()
+	if err != nil {
+		return ""
+	}
+	line := strings.TrimSpace(string(out))
+	// Format: KEY=value, or "-KEY" when unset.
+	if eq := strings.IndexByte(line, '='); eq >= 0 {
+		return line[eq+1:]
+	}
+	return ""
+}
+
+// displayErr surfaces an error to the user via tmux and also returns it so
+// the process exits non-zero.
+func displayErr(msg string) error {
+	_ = exec.Command("tmux", "display-message", "csm: "+msg).Run()
+	return fmt.Errorf("%s", msg)
+}

--- a/internal/manage/store.go
+++ b/internal/manage/store.go
@@ -1,0 +1,130 @@
+package manage
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// Agent records a managed agent spawned by `csm manage`. Persisted as one
+// JSON file per agent under managedDir(). The state file is the source of
+// truth for which agents csm manages; the CSM_MANAGED env var on the
+// spawned process is only a secondary signal.
+type Agent struct {
+	Project    string    `json:"project"`    // base name of the source repo
+	Name       string    `json:"name"`       // agent-1, agent-2, ...
+	Repo       string    `json:"repo"`       // toplevel of the source repo
+	Worktree   string    `json:"worktree"`   // worktree checkout path
+	Branch     string    `json:"branch"`     // csm/<project>/<agent>
+	TmuxWindow string    `json:"tmuxWindow"` // tmux window name (== Name)
+	CreatedAt  time.Time `json:"createdAt"`
+}
+
+// managedDirFn is overridable in tests.
+var managedDirFn = defaultManagedDir
+
+func defaultManagedDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".claude-monitor", "managed"), nil
+}
+
+// ManagedDir returns the directory where managed-agent records are persisted.
+func ManagedDir() (string, error) {
+	return managedDirFn()
+}
+
+func agentFileName(project, name string) string {
+	return fmt.Sprintf("%s-%s.json", project, name)
+}
+
+// SaveAgent persists an agent record using an atomic temp-write-then-rename.
+func SaveAgent(a Agent) error {
+	dir, err := ManagedDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create managed dir: %w", err)
+	}
+	data, err := json.MarshalIndent(a, "", "  ")
+	if err != nil {
+		return err
+	}
+	target := filepath.Join(dir, agentFileName(a.Project, a.Name))
+	tmp, err := os.CreateTemp(dir, agentFileName(a.Project, a.Name)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op if rename succeeded
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, target)
+}
+
+// ListAgents returns all persisted agent records. A missing managed dir is
+// not an error — it just means no agents have been spawned yet.
+func ListAgents() ([]Agent, error) {
+	dir, err := ManagedDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var agents []Agent
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue // skip unreadable records rather than failing the whole list
+		}
+		var a Agent
+		if err := json.Unmarshal(data, &a); err != nil {
+			continue
+		}
+		agents = append(agents, a)
+	}
+	sort.Slice(agents, func(i, j int) bool {
+		return agents[i].CreatedAt.Before(agents[j].CreatedAt)
+	})
+	return agents, nil
+}
+
+// nextAgentName returns the next free agent-N name for a project, based on
+// the highest existing index. Names are not reused even after cleanup
+// within the same csm session lifetime — gaps are fine.
+func nextAgentName(project string) (string, error) {
+	agents, err := ListAgents()
+	if err != nil {
+		return "", err
+	}
+	max := 0
+	for _, a := range agents {
+		if a.Project != project {
+			continue
+		}
+		var n int
+		if _, err := fmt.Sscanf(a.Name, "agent-%d", &n); err == nil && n > max {
+			max = n
+		}
+	}
+	return fmt.Sprintf("agent-%d", max+1), nil
+}

--- a/main.go
+++ b/main.go
@@ -28,6 +28,13 @@ func main() {
 		}
 		return
 	}
+	if len(os.Args) > 1 && os.Args[1] == "__spawn" {
+		if err := manage.Spawn(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "spawn: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	// Parse flags
 	listOnce := flag.Bool("l", false, "List sessions once and exit")


### PR DESCRIPTION
## Summary

Slice 2a of the orchestrator. Adds the first management capability: **press `Ctrl-n` inside `csm manage` to spawn a new Claude agent.**

The flow:
1. `Ctrl-n` (root key table, no prefix) opens a tmux prompt for a project directory, pre-filled with where `csm manage` was launched.
2. Creates an isolated git worktree at `~/.claude-monitor/worktrees/<project>/<agent>` on branch `csm/<project>/<agent>`.
3. Opens a new tmux window running `claude` in that worktree (with `CSM_MANAGED=1` / `CSM_AGENT=<name>` env).
4. Records the agent under `~/.claude-monitor/managed/<project>-<agent>.json` — the source of truth for later listing/cleanup.

Worktree isolation is the answer to "how do two agents avoid tangling in the same repo" — each gets its own checkout and branch.

### Notes
- **Stacks on #45** (slice 1). This PR targets `feature/manage-tmux-skeleton` so the diff shows only 2a. Merge #45 first.
- The `Ctrl-n` binding is server-global by tmux's nature; the `csm __spawn` helper guards on being inside the `csm` session, so it's inert elsewhere (will tighten with key-tables if needed in 2b).
- Status bar is hidden again (no switcher UX yet — returns in 2b).
- Naming hygiene for a future second agent type: `claude` is hardcoded in exactly one place (`spawn.go`), internal types say "agent" not "claude". No premature abstraction.

### Out of scope (slice 2b)
- The narrow sidebar + managed-vs-external grouping
- Agent/window switching UI
- Worktree cleanup, prompts, reconcile-on-exit

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] git worktree commands verified against a scratch repo (toplevel detect, add-with-branch, existing-branch failure)
- [x] `__spawn` guard rejects running outside the csm session
- [x] `Ctrl-n` root binding installs via `source-file` (verified live)
- [x] End-to-end: `Ctrl-n` → prompt → `claude` spawns in worktree; state file, worktree, and `git worktree list` all correct
- [ ] Reviewer: try a second spawn → `agent-2` with distinct worktree/branch/window
- [ ] Reviewer: non-git dir at prompt → tmux error, nothing created

🤖 Generated with [Claude Code](https://claude.com/claude-code)